### PR TITLE
 Fix rowSpan on DecisionTable input and annotations sections. Also valid for DMN Runner table. (and future SceSim!)

### DIFF
--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -234,18 +234,6 @@ export function DecisionTableExpression(
       })
     );
 
-    const inputSection = {
-      groupType: DecisionTableColumnType.InputClause,
-      id: "Inputs",
-      accessor: "Inputs" as any,
-      label: "Inputs",
-      dataType: undefined as any,
-      cssClasses: "decision-table--input",
-      isRowIndexColumn: false,
-      columns: inputColumns,
-      width: undefined,
-    };
-
     const outputSection = {
       groupType: DecisionTableColumnType.OutputClause,
       id: "Outputs",
@@ -258,20 +246,7 @@ export function DecisionTableExpression(
       width: undefined,
     };
 
-    const annotationSection = {
-      groupType: DecisionTableColumnType.Annotation,
-      id: "Annotations",
-      accessor: "Annotations" as any,
-      label: "Annotations",
-      cssClasses: "decision-table--annotation",
-      columns: annotationColumns,
-      isInlineEditable: false,
-      isRowIndexColumn: false,
-      dataType: undefined as any,
-      width: undefined,
-    };
-
-    return [inputSection, outputSection, annotationSection];
+    return [...inputColumns, outputSection, ...annotationColumns];
   }, [
     decisionTableExpression.annotations,
     decisionTableExpression.dataType,

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
@@ -162,6 +162,7 @@ export function BeeTableTd<R extends object>({
     tdRef,
     rowIndex,
     columnIndex,
+    column.columns?.length ?? 1,
     undefined,
     getValue
   );

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTdForAdditionalRow.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTdForAdditionalRow.tsx
@@ -54,7 +54,12 @@ export function BeeTableTdForAdditionalRow<R extends object>({
     column.width ? Math.max(lastColumnMinWidth ?? column.minWidth ?? 0, column.width ?? 0) : undefined
   );
 
-  const { cssClasses, onMouseDown, onDoubleClick } = useBeeTableSelectableCell(tdRef, rowIndex, columnIndex);
+  const { cssClasses, onMouseDown, onDoubleClick } = useBeeTableSelectableCell(
+    tdRef,
+    rowIndex,
+    columnIndex,
+    column.columns?.length ?? 1
+  );
 
   return isEmptyCell ? (
     <td

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
@@ -128,6 +128,7 @@ export function BeeTableTh<R extends object>({
     thRef,
     rowIndex,
     columnIndex,
+    column.columns?.length ?? 1,
     undefined,
     useCallback(() => {
       if (column.dataType) {


### PR DESCRIPTION
This PR address `rowSpan` for decision table inputs and annotations in DMN expression editor.

The state of the DMN Runner table is unchanged comparing `bee-reisizing-perf` branch

I am open to naming suggestion for new API parts instead of currently introduced `mergedHeaderGroups` and `MergedGroups`.

![Screenshot_20230202_095554](https://user-images.githubusercontent.com/8044780/216282824-810f04a2-a822-471d-a1e4-fcc5476b851a.png)
