### PR TITLE
Better labels for HitPolicy selector. All of them should have a good …

### DIFF
--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/HitPolicySelector.css
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/HitPolicySelector.css
@@ -26,8 +26,26 @@
   padding-bottom: 10px;
 }
 
-.boxed-expression-provider .hit-policy-container .builtin-aggregator-section {
+.hit-policy-section,
+.hit-policy-aggregator-section {
+  display: flex;
+  width: 600px;
+}
+
+.boxed-expression-provider .hit-policy-container .hit-policy-aggregator-section {
   padding-top: 10px;
+}
+
+.hit-policy-selectbox {
+  float: left;
+  flex: 1;
+  width: 200px;
+}
+
+.hit-policy-explanation {
+  padding-left: 14px;
+  flex: 3;
+  width: 400px;
 }
 
 .boxed-expression-provider .selected-hit-policy {

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/HitPolicySelector.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/HitPolicySelector.tsx
@@ -27,6 +27,7 @@ import { PopoverPosition } from "@patternfly/react-core/dist/js/components/Popov
 import * as _ from "lodash";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { useBoxedExpressionEditor } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
+import { Text, TextVariants } from "@patternfly/react-core/dist/js/components/Text";
 
 export interface HitPolicySelectorProps {
   /** Pre-selected hit policy */
@@ -58,6 +59,58 @@ export function HitPolicySelector({
     [selectedHitPolicy]
   );
 
+  const hitPolicyHelp = useMemo(() => {
+    switch (selectedHitPolicy) {
+      case DecisionTableExpressionDefinitionHitPolicy.Unique:
+        return i18n.hitPolicyHelp.unique;
+      case DecisionTableExpressionDefinitionHitPolicy.First:
+        return i18n.hitPolicyHelp.first;
+      case DecisionTableExpressionDefinitionHitPolicy.Priority:
+        return i18n.hitPolicyHelp.priority;
+      case DecisionTableExpressionDefinitionHitPolicy.Any:
+        return i18n.hitPolicyHelp.any;
+      case DecisionTableExpressionDefinitionHitPolicy.Collect:
+        return i18n.hitPolicyHelp.collect;
+      case DecisionTableExpressionDefinitionHitPolicy.RuleOrder:
+        return i18n.hitPolicyHelp.ruleOrder;
+      case DecisionTableExpressionDefinitionHitPolicy.OutputOrder:
+        return i18n.hitPolicyHelp.outputOrder;
+      default:
+        return i18n.hitPolicyHelp.unique;
+    }
+  }, [
+    selectedHitPolicy,
+    i18n.hitPolicyHelp.unique,
+    i18n.hitPolicyHelp.first,
+    i18n.hitPolicyHelp.priority,
+    i18n.hitPolicyHelp.any,
+    i18n.hitPolicyHelp.collect,
+    i18n.hitPolicyHelp.ruleOrder,
+    i18n.hitPolicyHelp.outputOrder,
+  ]);
+
+  const aggregatorHelp = useMemo(() => {
+    switch (selectedBuiltInAggregator) {
+      case DecisionTableExpressionDefinitionBuiltInAggregation.SUM:
+        return i18n.builtInAggregatorHelp.sum;
+      case DecisionTableExpressionDefinitionBuiltInAggregation.COUNT:
+        return i18n.builtInAggregatorHelp.count;
+      case DecisionTableExpressionDefinitionBuiltInAggregation.MIN:
+        return i18n.builtInAggregatorHelp.min;
+      case DecisionTableExpressionDefinitionBuiltInAggregation.MAX:
+        return i18n.builtInAggregatorHelp.max;
+      default:
+        return i18n.builtInAggregatorHelp.none;
+    }
+  }, [
+    selectedBuiltInAggregator,
+    i18n.builtInAggregatorHelp.sum,
+    i18n.builtInAggregatorHelp.count,
+    i18n.builtInAggregatorHelp.min,
+    i18n.builtInAggregatorHelp.max,
+    i18n.builtInAggregatorHelp.none,
+  ]);
+
   const onHitPolicySelectToggle = useCallback((isOpen) => {
     return setHitPolicySelectOpen(isOpen);
   }, []);
@@ -68,6 +121,7 @@ export function HitPolicySelector({
 
   const hitPolicySelectionCallback = useCallback(
     (event: React.MouseEvent, itemId: string) => {
+      event.stopPropagation();
       const updatedHitPolicy = itemId as DecisionTableExpressionDefinitionHitPolicy;
       onHitPolicySelected(updatedHitPolicy);
       setHitPolicySelectOpen(false);
@@ -77,6 +131,7 @@ export function HitPolicySelector({
 
   const builtInAggregatorSelectionCallback = useCallback(
     (event: React.MouseEvent, itemId: string) => {
+      event.stopPropagation();
       onBuiltInAggregatorSelected(itemId as DecisionTableExpressionDefinitionBuiltInAggregation);
       setBuiltInAggregatorSelectOpen(false);
     },
@@ -93,47 +148,67 @@ export function HitPolicySelector({
       body={
         <div className="hit-policy-container">
           <div className="hit-policy-section">
-            <label>{i18n.hitPolicy}</label>
-            <Select
-              className="hit-policy-selector"
-              menuAppendTo={editorRef.current ?? "inline"}
-              ouiaId="hit-policy-selector"
-              variant={SelectVariant.single}
-              onToggle={onHitPolicySelectToggle}
-              onSelect={hitPolicySelectionCallback}
-              isOpen={hitPolicySelectOpen}
-              selections={selectedHitPolicy}
-            >
-              {_.map(Object.values(DecisionTableExpressionDefinitionHitPolicy), (key) => (
-                <SelectOption key={key} value={key} data-ouia-component-id={key}>
-                  {key}
-                </SelectOption>
-              ))}
-            </Select>
+            <div className="hit-policy-selectbox">
+              <Text component={TextVariants.h3}>{i18n.hitPolicy}</Text>
+              <Select
+                className="hit-policy-selector"
+                menuAppendTo={editorRef.current ?? "inline"}
+                ouiaId="hit-policy-selector"
+                variant={SelectVariant.single}
+                onToggle={onHitPolicySelectToggle}
+                onSelect={hitPolicySelectionCallback}
+                isOpen={hitPolicySelectOpen}
+                selections={selectedHitPolicy}
+              >
+                {_.map(Object.values(DecisionTableExpressionDefinitionHitPolicy), (key) => (
+                  <SelectOption key={key} value={key} data-ouia-component-id={key}>
+                    {key}
+                  </SelectOption>
+                ))}
+              </Select>
+            </div>
+            <div className="hit-policy-explanation">
+              <Text component={TextVariants.h3}>{selectedHitPolicy}</Text>
+              <Text component={TextVariants.p}>{hitPolicyHelp}</Text>
+            </div>
           </div>
-          <div className="builtin-aggregator-section">
-            <label>{i18n.builtInAggregator}</label>
-            <Select
-              className="builtin-aggregator-selector"
-              menuAppendTo={editorRef.current ?? "inline"}
-              ouiaId="builtin-aggregator-selector"
-              isDisabled={!builtInAggregatorEnabled}
-              variant={SelectVariant.single}
-              onToggle={onBuiltInAggregatorSelectToggle}
-              onSelect={builtInAggregatorSelectionCallback}
-              isOpen={builtInAggregatorSelectOpen}
-              selections={selectedBuiltInAggregator}
-            >
-              {_.map(Object.keys(DecisionTableExpressionDefinitionBuiltInAggregation), (key) => (
-                <SelectOption
-                  key={key}
-                  value={(DecisionTableExpressionDefinitionBuiltInAggregation as any)[key]}
-                  data-ouia-component-id={key}
-                >
-                  {key}
-                </SelectOption>
-              ))}
-            </Select>
+          <div className="hit-policy-aggregator-section">
+            <div className="hit-policy-selectbox">
+              {selectedHitPolicy === DecisionTableExpressionDefinitionHitPolicy.Collect && (
+                <>
+                  <Text component={TextVariants.h3}>{i18n.builtInAggregator}</Text>
+                  <Select
+                    className="builtin-aggregator-selector"
+                    menuAppendTo={editorRef.current ?? "inline"}
+                    ouiaId="builtin-aggregator-selector"
+                    isDisabled={!builtInAggregatorEnabled}
+                    variant={SelectVariant.single}
+                    onToggle={onBuiltInAggregatorSelectToggle}
+                    onSelect={builtInAggregatorSelectionCallback}
+                    isOpen={builtInAggregatorSelectOpen}
+                    selections={selectedBuiltInAggregator}
+                  >
+                    {_.map(Object.keys(DecisionTableExpressionDefinitionBuiltInAggregation), (key) => (
+                      <SelectOption
+                        key={key}
+                        value={(DecisionTableExpressionDefinitionBuiltInAggregation as any)[key]}
+                        data-ouia-component-id={key}
+                      >
+                        {key}
+                      </SelectOption>
+                    ))}
+                  </Select>
+                </>
+              )}
+            </div>
+            <div className="hit-policy-explanation">
+              {selectedHitPolicy === DecisionTableExpressionDefinitionHitPolicy.Collect && (
+                <Text component={TextVariants.h3}>{i18n.builtInAggregator}</Text>
+              )}
+              {selectedHitPolicy === DecisionTableExpressionDefinitionHitPolicy.Collect && (
+                <Text component={TextVariants.p}>{aggregatorHelp}</Text>
+              )}
+            </div>
           </div>
         </div>
       }

--- a/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/packages/boxed-expression-component/src/i18n/BoxedExpressionEditorI18n.ts
@@ -20,6 +20,13 @@ import { CommonI18n } from "@kie-tools/i18n-common-dictionary";
 interface BoxedExpressionEditorDictionary extends ReferenceDictionary {
   addParameter: string;
   builtInAggregator: string;
+  builtInAggregatorHelp: {
+    sum: string;
+    count: string;
+    min: string;
+    max: string;
+    none: string;
+  };
   choose: string;
   columns: string;
   columnOperations: {
@@ -50,6 +57,15 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary {
   delete: string;
   function: string;
   hitPolicy: string;
+  hitPolicyHelp: {
+    unique: string;
+    first: string;
+    priority: string;
+    any: string;
+    collect: string;
+    ruleOrder: string;
+    outputOrder: string;
+  };
   inputClause: string;
   invocation: string;
   list: string;

--- a/packages/boxed-expression-component/src/i18n/locales/en.ts
+++ b/packages/boxed-expression-component/src/i18n/locales/en.ts
@@ -21,6 +21,13 @@ export const en: BoxedExpressionEditorI18n = {
   ...en_common,
   addParameter: "Add parameter",
   builtInAggregator: "Builtin Aggregator",
+  builtInAggregatorHelp: {
+    sum: "Outputs the sum of all collected values. Values must be numeric.",
+    count: "Outputs the number of matching rules.",
+    min: "Outputs the minimum value among the matches. The resulting values must be comparable, such as numbers, dates or text (lexicographic order).",
+    max: "Outputs the maximum value among the matches. The resulting values must be comparable, such as numbers, dates or text (lexicographic order).",
+    none: "Aggregates values in an arbitrary list.",
+  },
   choose: "Choose...",
   class: "class",
   columnOperations: {
@@ -54,6 +61,18 @@ export const en: BoxedExpressionEditorI18n = {
   enterText: "Enter Text",
   function: "Function",
   hitPolicy: "Hit Policy",
+  hitPolicyHelp: {
+    unique: "Permits only one rule to match. Any overlap raises an error.",
+    first: "Uses the first match in rule order.",
+    priority:
+      "Permits multiple rules to match, with different outputs. The output that comes first in the output values list is selected.",
+    any: "Permits multiple rules to match, but they must all have the same output. If multiple matching rules do not have the same output, an error is raised.",
+    collect: "Aggregates output from multiple rules based on an aggregation function.",
+    ruleOrder:
+      "Collects output from multiple rules into list ordered according to rules order. It is very similar as 'Collect' without any aggregation function, but with explicit consistent ordering in the final list as defined in the table.",
+    outputOrder:
+      "Collects output from multiple rules into list ordered using the same sorting mechanism as 'Priority' hit policy.",
+  },
   inputClause: "INPUT CLAUSE",
   invocation: "Invocation",
   list: "List",


### PR DESCRIPTION
…short description too.

The hit policy selector is changed to contain explanation of hit policy and aggregator choices.

If user selected a hit policy, that doesn't use aggregator. the popover design is:
![Screenshot_20230210_071145](https://user-images.githubusercontent.com/8044780/218016600-c4577bc6-c5e0-4cb9-b926-fffaa03bf507.png)


If user selected the collect hit policy, the popover design is:
![Screenshot_20230210_071202](https://user-images.githubusercontent.com/8044780/218016587-5c71d1aa-066e-417f-955a-16abce4519fb.png)

