### PR TITLE
Nested Default Expressions

### DIFF
--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
@@ -42,24 +42,19 @@ export const ExpressionContainer: React.FunctionComponent<ExpressionContainerPro
   const { beeGwtService } = useBoxedExpressionEditor();
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
-  const getDefaultExpressionDefinition = useCallback(
-    (logicType) => beeGwtService!.getDefaultExpressionDefinition(logicType),
-    [beeGwtService]
-  );
-
   const nestedExpressionContainer = useNestedExpressionContainer();
 
   const onLogicTypeSelected = useCallback(
     (logicType) => {
       setExpression((prev) => ({
-        ...getDefaultExpressionDefinition(logicType),
+        ...beeGwtService!.getDefaultExpressionDefinition(logicType),
         logicType,
         isNested,
         id: prev.id ?? generateUuid(),
         name: prev.name ?? DEFAULT_EXPRESSION_NAME,
       }));
     },
-    [getDefaultExpressionDefinition, isNested, setExpression]
+    [beeGwtService, isNested, setExpression]
   );
 
   const onLogicTypeReset = useCallback(() => {

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
@@ -23,7 +23,6 @@ import {
   useBoxedExpressionEditor,
   useBoxedExpressionEditorDispatch,
 } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
-import { getDefaultExpressionDefinitionByLogicType } from "../defaultExpression";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
 import { useNestedExpressionContainer } from "../../resizing/NestedExpressionContainerContext";
 
@@ -44,11 +43,7 @@ export const ExpressionContainer: React.FunctionComponent<ExpressionContainerPro
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
   const getDefaultExpressionDefinition = useCallback(
-    (isNested, logicType, prev, containerWidth) => {
-      return isNested
-        ? getDefaultExpressionDefinitionByLogicType(logicType, prev, containerWidth)
-        : beeGwtService!.getDefaultExpressionDefinition(logicType);
-    },
+    (logicType) => beeGwtService!.getDefaultExpressionDefinition(logicType),
     [beeGwtService]
   );
 
@@ -57,14 +52,14 @@ export const ExpressionContainer: React.FunctionComponent<ExpressionContainerPro
   const onLogicTypeSelected = useCallback(
     (logicType) => {
       setExpression((prev) => ({
-        ...getDefaultExpressionDefinition(isNested, logicType, prev, nestedExpressionContainer.resizingWidth.value),
+        ...getDefaultExpressionDefinition(logicType),
         logicType,
         isNested,
         id: prev.id ?? generateUuid(),
         name: prev.name ?? DEFAULT_EXPRESSION_NAME,
       }));
     },
-    [getDefaultExpressionDefinition, isNested, nestedExpressionContainer.resizingWidth.value, setExpression]
+    [getDefaultExpressionDefinition, isNested, setExpression]
   );
 
   const onLogicTypeReset = useCallback(() => {

--- a/packages/boxed-expression-component/src/expressions/defaultExpression.ts
+++ b/packages/boxed-expression-component/src/expressions/defaultExpression.ts
@@ -195,11 +195,29 @@ export function getDefaultExpressionDefinitionByLogicType(
           dataType: DmnBuiltInDataType.Undefined,
           width: DECISION_TABLE_INPUT_DEFAULT_WIDTH,
         },
+        {
+          id: generateUuid(),
+          name: "input-2",
+          dataType: DmnBuiltInDataType.Undefined,
+          width: DECISION_TABLE_INPUT_DEFAULT_WIDTH,
+        },
       ],
       output: [
         {
           id: generateUuid(),
           name: "output-1",
+          dataType: DmnBuiltInDataType.Undefined,
+          width: DECISION_TABLE_OUTPUT_DEFAULT_WIDTH,
+        },
+        {
+          id: generateUuid(),
+          name: "output-2",
+          dataType: DmnBuiltInDataType.Undefined,
+          width: DECISION_TABLE_OUTPUT_DEFAULT_WIDTH,
+        },
+        {
+          id: generateUuid(),
+          name: "output-3",
           dataType: DmnBuiltInDataType.Undefined,
           width: DECISION_TABLE_OUTPUT_DEFAULT_WIDTH,
         },
@@ -213,8 +231,12 @@ export function getDefaultExpressionDefinitionByLogicType(
       rules: [
         {
           id: generateUuid(),
-          inputEntries: [DECISION_TABLE_INPUT_DEFAULT_VALUE],
-          outputEntries: [DECISION_TABLE_OUTPUT_DEFAULT_VALUE],
+          inputEntries: [DECISION_TABLE_INPUT_DEFAULT_VALUE, DECISION_TABLE_INPUT_DEFAULT_VALUE],
+          outputEntries: [
+            DECISION_TABLE_OUTPUT_DEFAULT_VALUE,
+            DECISION_TABLE_OUTPUT_DEFAULT_VALUE,
+            DECISION_TABLE_OUTPUT_DEFAULT_VALUE,
+          ],
           annotationEntries: ["// Your annotations here"],
         },
       ],

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/ExpressionEditorService.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/jsinterop/util/ExpressionEditorService.java
@@ -38,7 +38,8 @@ public class ExpressionEditorService {
     }
 
     /**
-     * Given a logic type, it returns its default Expression definition. Currently working for Root expressions only.
+     * Given a logic type, it returns its default Expression definition based on the current Expression.
+     * It supports both root and nested expressions.
      * @param logicType The selected logicType (see. ExpressionType.java)
      * @return The default Expression definition as ExpressionProps
      */


### PR DESCRIPTION
@tiagobento GWT Layer already supports nested default expression management, so I simply modified the TS-REACT layer to always call the GWT layer to retrieve the default expression for all cases. 
I restored the DefaultExpression.ts structure, now it's used in the showcase only.

You can merge it whenever you want.