### PR TITLE
kie-issues#162: Setup rowSpan for header cells on tables with multiple header levels on Boxed Expression Editor table

### DIFF
--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -245,35 +245,6 @@ export function DecisionTableExpression(
       }
     );
 
-    // FIXME: Delete this.
-    //
-    // Testing multiple rowSpanned sections..
-    //
-    // const outputSection2 = {
-    //   groupType: DecisionTableColumnType.OutputClause,
-    //   id: "Outputs2",
-    //   accessor: "decision-table-expression-2" as any, // FIXME: Tiago -> ?
-    //   label: (decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME) + "2",
-    //   dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
-    //   cssClasses: "decision-table--output",
-    //   isRowIndexColumn: false,
-    //   width: undefined,
-    //   columns: (decisionTableExpression.output ?? []).map((outputClause, outputIndex) => ({
-    //     accessor: outputClause.id ?? generateUuid(),
-    //     id: outputClause.id+"2",
-    //     label: outputClause.name + "2",
-    //     dataType: outputClause.dataType,
-    //     width: outputClause.width ?? DECISION_TABLE_OUTPUT_MIN_WIDTH,
-    //     setWidth: setOutputColumnWidth(outputIndex) ,
-    //     minWidth: DECISION_TABLE_OUTPUT_MIN_WIDTH,
-    //     groupType: DecisionTableColumnType.OutputClause,
-    //     cssClasses: "decision-table--output",
-    //     isRowIndexColumn: false,
-    //   })),
-    // };
-    //
-    // return [...inputColumns, outputSection, ...annotationColumns, outputSection2];
-
     return [...inputColumns, outputSection, ...annotationColumns];
   }, [
     decisionTableExpression.annotations,

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -21,11 +21,9 @@ import {
   BeeTableHeaderVisibility,
   BeeTableOperation,
   BeeTableOperationConfig,
-  BeeTableProps,
   DecisionTableExpressionDefinition,
   DecisionTableExpressionDefinitionBuiltInAggregation,
   DecisionTableExpressionDefinitionHitPolicy,
-  DecisionTableExpressionDefinitionRuleEntry,
   DmnBuiltInDataType,
   generateUuid,
   getNextAvailablePrefixedName,
@@ -47,7 +45,6 @@ import {
   BeeTable,
   BeeTableCellUpdate,
   BeeTableColumnUpdate,
-  BeeTableEditableCellContent,
   BeeTableRef,
   getColumnsAtLastLevel,
 } from "../../table/BeeTable";
@@ -240,22 +237,10 @@ export function DecisionTableExpression(
       }
     );
 
-    const inputSection = {
-      groupType: DecisionTableColumnType.InputClause,
-      id: "Inputs",
-      accessor: "Inputs" as any,
-      label: "Inputs",
-      dataType: undefined as any,
-      cssClasses: "decision-table--input",
-      isRowIndexColumn: false,
-      columns: inputColumns,
-      width: undefined,
-    };
-
     const outputSection = {
       groupType: DecisionTableColumnType.OutputClause,
-      id: decisionTableExpression.id,
-      accessor: "decision-table-expression" as any, // FIXME: https://github.com/kiegroup/kie-issues/issues/169
+      id: "Outputs",
+      accessor: "decision-table-expression" as any, // FIXME: Tiago -> ?
       label: decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME,
       dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
       cssClasses: "decision-table--output",
@@ -264,20 +249,7 @@ export function DecisionTableExpression(
       width: undefined,
     };
 
-    const annotationSection = {
-      groupType: DecisionTableColumnType.Annotation,
-      id: "Annotations",
-      accessor: "Annotations" as any,
-      label: "Annotations",
-      cssClasses: "decision-table--annotation",
-      columns: annotationColumns,
-      isInlineEditable: false,
-      isRowIndexColumn: false,
-      dataType: undefined as any,
-      width: undefined,
-    };
-
-    return [inputSection, outputSection, annotationSection];
+    return [...inputColumns, outputSection, ...annotationColumns];
   }, [
     decisionTableExpression.annotations,
     decisionTableExpression.dataType,

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -203,8 +203,16 @@ export function DecisionTableExpression(
       })
     );
 
-    const outputColumns: ReactTable.Column<ROWTYPE>[] = (decisionTableExpression.output ?? []).map(
-      (outputClause, outputIndex) => ({
+    const outputSection = {
+      groupType: DecisionTableColumnType.OutputClause,
+      id: decisionTableExpression.id,
+      accessor: "decision-table-expression" as any, // FIXME: https://github.com/kiegroup/kie-issues/issues/169
+      label: decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME,
+      dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
+      cssClasses: "decision-table--output",
+      isRowIndexColumn: false,
+      width: undefined,
+      columns: (decisionTableExpression.output ?? []).map((outputClause, outputIndex) => ({
         accessor: outputClause.id ?? generateUuid(),
         id: outputClause.id,
         label: outputClause.name,
@@ -215,8 +223,8 @@ export function DecisionTableExpression(
         groupType: DecisionTableColumnType.OutputClause,
         cssClasses: "decision-table--output",
         isRowIndexColumn: false,
-      })
-    );
+      })),
+    };
 
     const annotationColumns: ReactTable.Column<ROWTYPE>[] = (decisionTableExpression.annotations ?? []).map(
       (annotation, annotationIndex) => {
@@ -237,17 +245,34 @@ export function DecisionTableExpression(
       }
     );
 
-    const outputSection = {
-      groupType: DecisionTableColumnType.OutputClause,
-      id: "Outputs",
-      accessor: "decision-table-expression" as any, // FIXME: Tiago -> ?
-      label: decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME,
-      dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
-      cssClasses: "decision-table--output",
-      isRowIndexColumn: false,
-      columns: outputColumns,
-      width: undefined,
-    };
+    // FIXME: Delete this.
+    //
+    // Testing multiple rowSpanned sections..
+    //
+    // const outputSection2 = {
+    //   groupType: DecisionTableColumnType.OutputClause,
+    //   id: "Outputs2",
+    //   accessor: "decision-table-expression-2" as any, // FIXME: Tiago -> ?
+    //   label: (decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME) + "2",
+    //   dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
+    //   cssClasses: "decision-table--output",
+    //   isRowIndexColumn: false,
+    //   width: undefined,
+    //   columns: (decisionTableExpression.output ?? []).map((outputClause, outputIndex) => ({
+    //     accessor: outputClause.id ?? generateUuid(),
+    //     id: outputClause.id+"2",
+    //     label: outputClause.name + "2",
+    //     dataType: outputClause.dataType,
+    //     width: outputClause.width ?? DECISION_TABLE_OUTPUT_MIN_WIDTH,
+    //     setWidth: setOutputColumnWidth(outputIndex) ,
+    //     minWidth: DECISION_TABLE_OUTPUT_MIN_WIDTH,
+    //     groupType: DecisionTableColumnType.OutputClause,
+    //     cssClasses: "decision-table--output",
+    //     isRowIndexColumn: false,
+    //   })),
+    // };
+    //
+    // return [...inputColumns, outputSection, ...annotationColumns, outputSection2];
 
     return [...inputColumns, outputSection, ...annotationColumns];
   }, [

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -123,6 +123,7 @@ export function JavaFunctionExpression({
   }, [
     functionExpression.classAndMethodNamesWidth,
     functionExpression.dataType,
+    functionExpression.id,
     functionExpression.name,
     parametersColumnHeader,
     setClassAndMethodNamesWidth,

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -304,7 +304,7 @@ function JavaFunctionExpressionLabelCell(props: React.PropsWithChildren<BeeTable
   }, [beeGwtService, isActive]);
 
   const getParameterLabelHelp = useCallback((): React.ReactNode => {
-    if (props.rowIndex === 1) {
+    if (props.rowIndex === 0) {
       return <code>org.kie.kogito.MyClass</code>;
     } else {
       return <code>doSomething(java.lang.Integer, double)</code>;

--- a/packages/boxed-expression-component/src/resizing/BeeTableResizableColumnsContext.tsx
+++ b/packages/boxed-expression-component/src/resizing/BeeTableResizableColumnsContext.tsx
@@ -3,7 +3,6 @@ import * as ReactTable from "react-table";
 import { useCallback, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { ResizerStopBehavior, ResizingWidth, useResizerRef, useResizingWidthsDispatch } from "./ResizingWidthsContext";
 import { BEE_TABLE_ROW_INDEX_COLUMN_WIDTH } from "./WidthConstants";
-import { getFlatListOfSubColumns } from "./FillingColumnResizingWidth";
 
 // TYPES
 

--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -365,7 +365,7 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
                 }
               : {
                   rows: { min: 0, max: rowCount - 1 },
-                  columns: { min: 1, max: columnCount(prev.active.rowIndex) - 1 },
+                  columns: { min: 1, max: Math.max(1, columnCount(prev.active.rowIndex) - 1) },
                 };
 
           const prevCoords =

--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -365,7 +365,7 @@ export function BeeTableSelectionContextProvider({ children }: React.PropsWithCh
                 }
               : {
                   rows: { min: 0, max: rowCount - 1 },
-                  columns: { min: 1, max: Math.max(1, columnCount(prev.active.rowIndex) - 1) },
+                  columns: { min: 1, max: columnCount(prev.active.rowIndex) - 1 },
                 };
 
           const prevCoords =

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTable.css
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTable.css
@@ -117,19 +117,13 @@
   box-shadow: 0px 0px 20px -5px darkgrey;
 }
 
-.expression-container .table-component table thead tr th:first-child {
-  border-right: 1px solid var(--pf-global--palette--black-400);
-}
 .expression-container .table-component table thead tr th {
   border-top: 1px solid var(--pf-global--palette--black-400);
   border-left: 1px solid var(--pf-global--palette--black-400);
-}
-.expression-container .table-component table thead tr th:last-child {
   border-right: 1px solid var(--pf-global--palette--black-400);
-}
-.expression-container .table-component table thead tr:last-child th {
   border-bottom: 1px solid var(--pf-global--palette--black-400);
 }
+
 .expression-container .table-component table tbody tr td:first-child {
   border-top: 1px solid var(--pf-global--palette--black-400);
   border-left: 1px solid var(--pf-global--palette--black-400);

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTable.tsx
@@ -287,7 +287,11 @@ export function BeeTableInternal<R extends object>({
       if (rowIndex >= 0) {
         return reactTableInstance.allColumns.length;
       } else {
-        return _.nth(reactTableInstance.headerGroups, rowIndex)!.headers.length;
+        return _.nth(reactTableInstance.headerGroups, rowIndex)!.headers.reduce(
+          (nonPlaceholderColumnCount, currentColumn) =>
+            nonPlaceholderColumnCount + (currentColumn.placeholderOf ? 0 : 1),
+          0
+        );
       }
     },
     [reactTableInstance.allColumns.length, reactTableInstance.headerGroups]

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTable.tsx
@@ -302,8 +302,7 @@ export function BeeTableInternal<R extends object>({
         return reactTableInstance.allColumns.length;
       } else {
         return _.nth(reactTableInstance.headerGroups, rowIndex)!.headers.reduce(
-          (nonPlaceholderColumnCount, currentColumn) =>
-            nonPlaceholderColumnCount + (currentColumn.placeholderOf ? 0 : 1),
+          (acc, column) => acc + (column.placeholderOf ? 0 : 1),
           0
         );
       }

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTable.tsx
@@ -282,6 +282,20 @@ export function BeeTableInternal<R extends object>({
     [getRowKey]
   );
 
+  // For header area (rowIndex < 0), we need to 'getColumnCount' counts just real columns, not placeholders
+  // +-----------+----------+-----------+
+  // |     A     +          |     C     |
+  // +-----+-----+     B    +-----------+
+  // |  a  |  a  |          |  c  |  c  |
+  // +-----------+----------+-----+-----+
+  // | data cells
+  // | ....
+  //
+  // in this example just 'A' and 'C' have rowIndex set to -2
+  // So we need 'getColumnCount' returns number 2 for 'rowIndex' -2
+  //
+  // This is important for boundaries calucalted in 'BeeTableSelectionContext'
+  // We do not want to be able navigate horizontally between header cells with different 'rowIndex'
   const getColumnCount = useCallback(
     (rowIndex: number) => {
       if (rowIndex >= 0) {

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableContextMenuHandler.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableContextMenuHandler.tsx
@@ -69,9 +69,12 @@ export function BeeTableContextMenuHandler({
     if (!activeCell) {
       return undefined;
     }
+    const rowIndex = activeCell.rowIndex;
 
-    return reactTableInstance.allColumns;
-  }, [activeCell, reactTableInstance.allColumns]);
+    return rowIndex < 0 // Header cells to be read from headerGroups
+      ? _.nth(reactTableInstance.headerGroups, rowIndex)?.headers
+      : reactTableInstance.allColumns;
+  }, [activeCell, reactTableInstance.allColumns, reactTableInstance.headerGroups]);
 
   const column = useMemo(() => {
     if (!activeCell) {
@@ -160,16 +163,7 @@ export function BeeTableContextMenuHandler({
           assertUnreachable(operation);
       }
     },
-    [
-      i18n.columnOperations.insertRight,
-      i18n.columnOperations.insertLeft,
-      i18n.columnOperations.delete,
-      i18n.rowOperations.insertAbove,
-      i18n.rowOperations.insertBelow,
-      i18n.rowOperations.delete,
-      i18n.rowOperations.duplicate,
-      i18n.rowOperations.reset,
-    ]
+    [i18n]
   );
 
   const operationIcon = useCallback((operation: BeeTableOperation) => {

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableContextMenuHandler.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableContextMenuHandler.tsx
@@ -59,6 +59,7 @@ export function BeeTableContextMenuHandler({
   onColumnAdded,
   onColumnDeleted,
 }: BeeTableContextMenuHandlerProps) {
+  const { i18n } = useBoxedExpressionEditorI18n();
   const { setCurrentlyOpenContextMenu } = useBoxedExpressionEditor();
 
   const { activeCell } = useBeeTableSelection();
@@ -69,12 +70,8 @@ export function BeeTableContextMenuHandler({
       return undefined;
     }
 
-    const rowIndex = activeCell.rowIndex;
-
-    return rowIndex < 0 // Header cells to be read from headerGroups
-      ? _.nth(reactTableInstance.headerGroups, rowIndex)?.headers
-      : reactTableInstance.allColumns;
-  }, [activeCell, reactTableInstance.allColumns, reactTableInstance.headerGroups]);
+    return reactTableInstance.allColumns;
+  }, [activeCell, reactTableInstance.allColumns]);
 
   const column = useMemo(() => {
     if (!activeCell) {
@@ -140,28 +137,40 @@ export function BeeTableContextMenuHandler({
     ];
   }, [activeCell, columnOperations, reactTableInstance.rows.length]);
 
-  const operationLabel = useCallback((operation: BeeTableOperation) => {
-    switch (operation) {
-      case BeeTableOperation.ColumnInsertLeft:
-        return `Insert left`;
-      case BeeTableOperation.ColumnInsertRight:
-        return `Insert right`;
-      case BeeTableOperation.ColumnDelete:
-        return `Delete`;
-      case BeeTableOperation.RowInsertAbove:
-        return `Insert above`;
-      case BeeTableOperation.RowInsertBelow:
-        return `Insert below`;
-      case BeeTableOperation.RowDelete:
-        return `Delete`;
-      case BeeTableOperation.RowReset:
-        return `Reset`;
-      case BeeTableOperation.RowDuplicate:
-        return `Duplicate`;
-      default:
-        assertUnreachable(operation);
-    }
-  }, []);
+  const operationLabel = useCallback(
+    (operation: BeeTableOperation) => {
+      switch (operation) {
+        case BeeTableOperation.ColumnInsertLeft:
+          return i18n.columnOperations.insertLeft;
+        case BeeTableOperation.ColumnInsertRight:
+          return i18n.columnOperations.insertRight;
+        case BeeTableOperation.ColumnDelete:
+          return i18n.columnOperations.delete;
+        case BeeTableOperation.RowInsertAbove:
+          return i18n.rowOperations.insertAbove;
+        case BeeTableOperation.RowInsertBelow:
+          return i18n.rowOperations.insertBelow;
+        case BeeTableOperation.RowDelete:
+          return i18n.rowOperations.delete;
+        case BeeTableOperation.RowReset:
+          return i18n.rowOperations.reset;
+        case BeeTableOperation.RowDuplicate:
+          return i18n.rowOperations.duplicate;
+        default:
+          assertUnreachable(operation);
+      }
+    },
+    [
+      i18n.columnOperations.insertRight,
+      i18n.columnOperations.insertLeft,
+      i18n.columnOperations.delete,
+      i18n.rowOperations.insertAbove,
+      i18n.rowOperations.insertBelow,
+      i18n.rowOperations.delete,
+      i18n.rowOperations.duplicate,
+      i18n.rowOperations.reset,
+    ]
+  );
 
   const operationIcon = useCallback((operation: BeeTableOperation) => {
     switch (operation) {
@@ -196,9 +205,8 @@ export function BeeTableContextMenuHandler({
         return [];
       }
 
-      const columnIndex = activeCell.columnIndex;
       const rowIndex = activeCell.rowIndex;
-
+      const columnIndex = activeCell.columnIndex;
       switch (operation) {
         case BeeTableOperation.ColumnInsertLeft:
           onColumnAdded?.({
@@ -268,8 +276,6 @@ export function BeeTableContextMenuHandler({
       left: xPos,
     };
   }, [xPos, yPos]);
-
-  const { i18n } = useBoxedExpressionEditorI18n();
 
   return (
     <>

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableDefaultCell.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableDefaultCell.tsx
@@ -53,7 +53,7 @@ export function BeeTableDefaultCell<R extends object>({
 
   useEffect(() => {
     if (isActive) {
-      beeGwtService?.selectObject(typeof cellProps.value === "string" ? "" : cellProps.value.id);
+      beeGwtService?.selectObject(typeof cellProps.value === "string" ? "" : cellProps.value?.id);
     }
   }, [isActive, beeGwtService, cellProps]);
 
@@ -63,7 +63,7 @@ export function BeeTableDefaultCell<R extends object>({
       isActive={isActive}
       setEditing={setEditing}
       onChange={onCellChanged}
-      value={typeof cellProps.value === "string" ? cellProps.value : cellProps.value.content}
+      value={typeof cellProps.value === "string" ? cellProps.value : cellProps.value?.content}
       isReadOnly={isReadOnly}
       onFeelEnterKeyDown={navigateVertically}
       onFeelTabKeyDown={navigateHorizontally}

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
@@ -162,13 +162,11 @@ export function BeeTableHeader<R extends object>({
       rowIndex: number,
       column: ReactTable.ColumnInstance<R>,
       columnIndex: number,
-      done: Set<ReactTable.ColumnInstance<R>>,
+      visitedColumns: Set<ReactTable.ColumnInstance<R>>,
       rowSpan: number
     ) => JSX.Element
   >(
-    (rowIndex, _column, columnIndex, done, rowSpan) => {
-      const column = _column;
-
+    (rowIndex, column, columnIndex, visitedColumns, rowSpan) => {
       const thRef = React.createRef<HTMLTableCellElement>();
 
       const ret = column.isRowIndexColumn ? (
@@ -177,9 +175,8 @@ export function BeeTableHeader<R extends object>({
         </React.Fragment>
       ) : (
         <React.Fragment key={getColumnKey(column)}>
-          {!done.has(column) && (
+          {!visitedColumns.has(column) && (
             <BeeTableThResizable
-              firstColumnIndexOfGroup={reactTableInstance.allColumns.indexOf(column.columns?.[0] ?? column)}
               forwardRef={thRef}
               resizerStopBehavior={resizerStopBehavior}
               rowSpan={rowSpan}
@@ -240,6 +237,7 @@ export function BeeTableHeader<R extends object>({
                   {column.dataType ? (
                     <p className="expression-info-data-type pf-u-text-truncate data-type">({column.dataType})</p>
                   ) : null}
+                  ({rowIndex},{columnIndex})
                 </div>
               }
             />
@@ -247,7 +245,7 @@ export function BeeTableHeader<R extends object>({
         </React.Fragment>
       );
 
-      done.add(column);
+      visitedColumns.add(column);
       return ret;
     },
     [
@@ -290,20 +288,7 @@ export function BeeTableHeader<R extends object>({
   );
 
   const renderHeaderGroups = useCallback(() => {
-    const done = new Set<ReactTable.ColumnInstance<R>>();
-
-    function deepestPlaceholder(column: ReactTable.ColumnInstance<R>): {
-      placeholder: ReactTable.ColumnInstance<R>;
-      depth: number;
-    } {
-      let currentDepth = 1;
-      while (column.placeholderOf) {
-        column = column.placeholderOf;
-        currentDepth++;
-      }
-
-      return { placeholder: column, depth: currentDepth };
-    }
+    const visitedColumns = new Set<ReactTable.ColumnInstance<R>>();
 
     return reactTableInstance.headerGroups.map((headerGroup, index) => {
       // rowIndex === -1 --> Last headerGroup
@@ -315,26 +300,29 @@ export function BeeTableHeader<R extends object>({
       if (shouldRenderHeaderGroup(rowIndex)) {
         return (
           <tr key={key} {...props}>
-            {headerGroup.headers.map((column, columnIndex) => {
-              const { placeholder, depth } = deepestPlaceholder(column);
-              const result = renderColumn(rowIndex + depth - 1, placeholder, columnIndex, done, depth);
-              done.add(placeholder);
-              return result;
+            {headerGroup.headers.map((column, i) => {
+              const { placeholder, depth } = getDeepestPlaceholder(column);
+              const columnIndex = getColumnIndexOfHeader(reactTableInstance, placeholder, i);
+              return renderColumn(rowIndex + depth - 1, placeholder, columnIndex, visitedColumns, depth);
             })}
           </tr>
         );
       } else {
         return (
           <React.Fragment key={key}>
-            {headerGroup.headers.map((column, columnIndex) => (
-              <BeeTableThController
-                key={getColumnKey(column)}
-                columnIndex={columnIndex}
-                column={column}
-                reactTableInstance={reactTableInstance}
-                shouldRenderRowIndexColumn={shouldRenderRowIndexColumn}
-              />
-            ))}
+            {headerGroup.headers.map((column, i) => {
+              const { placeholder } = getDeepestPlaceholder(column);
+              const columnIndex = getColumnIndexOfHeader(reactTableInstance, placeholder, i);
+              return (
+                <BeeTableThController
+                  key={getColumnKey(column)}
+                  columnIndex={columnIndex}
+                  column={column}
+                  reactTableInstance={reactTableInstance}
+                  shouldRenderRowIndexColumn={shouldRenderRowIndexColumn}
+                />
+              );
+            })}
           </React.Fragment>
         );
       }
@@ -342,4 +330,27 @@ export function BeeTableHeader<R extends object>({
   }, [getColumnKey, reactTableInstance, renderColumn, shouldRenderHeaderGroup, shouldRenderRowIndexColumn]);
 
   return <>{<thead>{renderHeaderGroups()}</thead>}</>;
+}
+
+function getDeepestPlaceholder<R extends object>(column: ReactTable.ColumnInstance<R>) {
+  let currentDepth = 1;
+
+  while (column.placeholderOf) {
+    column = column.placeholderOf;
+    currentDepth++;
+  }
+
+  return {
+    placeholder: column,
+    depth: currentDepth,
+  };
+}
+
+function getColumnIndexOfHeader<R extends object>(
+  reactTableInstance: ReactTable.TableInstance<R>,
+  column: ReactTable.ColumnInstance<R>,
+  indexOnHeaderGroup: number
+) {
+  const leafColumnsIndex = reactTableInstance.allColumns.indexOf(column);
+  return leafColumnsIndex >= 0 ? leafColumnsIndex : indexOnHeaderGroup;
 }

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
@@ -295,14 +295,20 @@ export function BeeTableHeader<R extends object>({
       // rowIndex === -2 --> Second to last headerGroup
       // ... and so on
       const rowIndex = -(reactTableInstance.headerGroups.length - 1 - index + 1);
+      // set to -1 because of row index column
+      // row index column is not found by 'getColumnIndexOfHeader' in 'reactTableInstance.allColumns'
+      let lastParentalHeaderCellIndex = -1;
 
       const { key, ...props } = { ...headerGroup.getHeaderGroupProps(), style: {} };
       if (shouldRenderHeaderGroup(rowIndex)) {
         return (
           <tr key={key} {...props}>
-            {headerGroup.headers.map((column, i) => {
+            {headerGroup.headers.map((column) => {
               const { placeholder, depth } = getDeepestPlaceholder(column);
-              const columnIndex = getColumnIndexOfHeader(reactTableInstance, placeholder, i);
+              const columnIndex =
+                getColumnIndexOfHeader(reactTableInstance, placeholder) >= 0
+                  ? getColumnIndexOfHeader(reactTableInstance, placeholder)
+                  : ++lastParentalHeaderCellIndex;
               return renderColumn(rowIndex + depth - 1, placeholder, columnIndex, visitedColumns, depth);
             })}
           </tr>
@@ -310,9 +316,13 @@ export function BeeTableHeader<R extends object>({
       } else {
         return (
           <React.Fragment key={key}>
-            {headerGroup.headers.map((column, i) => {
+            {headerGroup.headers.map((column) => {
               const { placeholder } = getDeepestPlaceholder(column);
-              const columnIndex = getColumnIndexOfHeader(reactTableInstance, placeholder, i);
+              const columnIndex =
+                getColumnIndexOfHeader(reactTableInstance, placeholder) >= 0
+                  ? getColumnIndexOfHeader(reactTableInstance, placeholder)
+                  : ++lastParentalHeaderCellIndex;
+
               return (
                 <BeeTableThController
                   key={getColumnKey(column)}
@@ -348,9 +358,7 @@ function getDeepestPlaceholder<R extends object>(column: ReactTable.ColumnInstan
 
 function getColumnIndexOfHeader<R extends object>(
   reactTableInstance: ReactTable.TableInstance<R>,
-  column: ReactTable.ColumnInstance<R>,
-  indexOnHeaderGroup: number
+  column: ReactTable.ColumnInstance<R>
 ) {
-  const leafColumnsIndex = reactTableInstance.allColumns.indexOf(column);
-  return leafColumnsIndex >= 0 ? leafColumnsIndex : indexOnHeaderGroup;
+  return reactTableInstance.allColumns.indexOf(column);
 }

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
@@ -237,7 +237,6 @@ export function BeeTableHeader<R extends object>({
                   {column.dataType ? (
                     <p className="expression-info-data-type pf-u-text-truncate data-type">({column.dataType})</p>
                   ) : null}
-                  ({rowIndex},{columnIndex})
                 </div>
               }
             />

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
@@ -295,9 +295,7 @@ export function BeeTableHeader<R extends object>({
       // rowIndex === -2 --> Second to last headerGroup
       // ... and so on
       const rowIndex = -(reactTableInstance.headerGroups.length - 1 - index + 1);
-      // set to -1 because of row index column
-      // row index column is not found by 'getColumnIndexOfHeader' in 'reactTableInstance.allColumns'
-      let lastParentalHeaderCellIndex = -1;
+      let lastParentalHeaderCellIndex = 0;
 
       const { key, ...props } = { ...headerGroup.getHeaderGroupProps(), style: {} };
       if (shouldRenderHeaderGroup(rowIndex)) {
@@ -308,7 +306,7 @@ export function BeeTableHeader<R extends object>({
               const columnIndex =
                 getColumnIndexOfHeader(reactTableInstance, placeholder) >= 0
                   ? getColumnIndexOfHeader(reactTableInstance, placeholder)
-                  : ++lastParentalHeaderCellIndex;
+                  : lastParentalHeaderCellIndex++;
               return renderColumn(rowIndex + depth - 1, placeholder, columnIndex, visitedColumns, depth);
             })}
           </tr>
@@ -321,7 +319,7 @@ export function BeeTableHeader<R extends object>({
               const columnIndex =
                 getColumnIndexOfHeader(reactTableInstance, placeholder) >= 0
                   ? getColumnIndexOfHeader(reactTableInstance, placeholder)
-                  : ++lastParentalHeaderCellIndex;
+                  : lastParentalHeaderCellIndex++;
 
               return (
                 <BeeTableThController

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableThResizable.tsx
@@ -36,7 +36,6 @@ export interface BeeTableThResizableProps<R extends object> {
   column: ReactTable.ColumnInstance<R>;
   columnIndex: number;
   rowIndex: number;
-  firstColumnIndexOfGroup: number;
   rowSpan: number;
   editColumnLabel?: string | { [groupType: string]: string };
   isEditableHeader: boolean;
@@ -58,7 +57,6 @@ export function BeeTableThResizable<R extends object>({
   column,
   columnIndex,
   rowIndex,
-  firstColumnIndexOfGroup,
   shouldRenderRowIndexColumn,
   rowSpan,
   isEditableHeader,


### PR DESCRIPTION
This PR is a replacement of https://github.com/tiagobento/kie-tools/pull/65 and closes https://github.com/kiegroup/kie-issues/issues/162

The effect of changes in this PR, should ensure, that the DMN Decision table headers have two different row spans.
Input columns and annotation columns headers should have rowSpan equal to 2. Output clause columns should have rowSpan equal to 1.

### before
![Screenshot 2023-03-29 120947](https://user-images.githubusercontent.com/8044780/228501827-f9b369bf-c359-4e89-869f-50053bd554ae.png)

### after
![Screenshot 2023-03-29 122931](https://user-images.githubusercontent.com/8044780/228507806-9fd7a33c-8b5b-44a9-988b-2a9a77e8546b.png)

### Manual checks
- [ ] Click on header cell -  Single header cell should be selected
- [ ] Click on header cell - Properties panel should be updated accordingly, especially check DT Input and DT output restrictions in properties panel
- [ ] Select header cell(s) by drag and drop - Properties panel should be empty when multiple header cells are selected
- [ ] Select header cell(s) by drag and drop - User shouldn't be able to mix cell types in selections, just data, header or row index cell should belong to group of selected cells
- [ ] Select header cell(s) by keyboard (SHIFT + ARROW KEY) - Properties panel should be empty when multiple header cells are selected
- [ ] Select header cell(s) by keyboard (SHIFT + ARROW KEY) - User shouldn't be able to mix cell types in selections, just data, header or row index cell should belong to group of selected cells
- [ ] Select All header cells (CTRL + A) - if header cell is selected, just header cells are selected
- [ ] Select All header cells (CTRL + A) - if data cell is selected, just data cells are selected
- [ ] Select All header cells (CTRL + A) - if row index cell is selected, just row index cells are selected
- [ ] Keyboard navigation  - user is able to navigate among header cells
- [ ] Keyboard navigation  - user is able to navigate among data cells
- [ ] Keyboard navigation - user is able to navigate among row index cells
- [ ] Keyboard navigation - user **is not** able navigate between two different types of cells, for example from data to header
- [ ] More than 2 header levels - solution should work also for tables with more than 2 level of headers
- [ ] DMN Runner tabular view - user should be able to run its DMN model in DMN runner tabular view
- [ ] Header cell border should have same width for all cells
- [ ] Resizer should work for all header cells
- [ ] Context menu actions should work for all header cells

### more header levels
to see changes for more levels in headers, you can replace DT column definition as:
```
    const inputColumns: ReactTable.Column<ROWTYPE>[] = (decisionTableExpression.input ?? []).map(
      (inputClause, inputIndex) => ({
        accessor: inputClause.id ?? generateUuid(),
        label: inputClause.name,
        id: inputClause.id,
        dataType: inputClause.dataType,
        width: inputClause.width ?? DECISION_TABLE_INPUT_MIN_WIDTH,
        setWidth: setInputColumnWidth(inputIndex),
        minWidth: DECISION_TABLE_INPUT_MIN_WIDTH,
        groupType: DecisionTableColumnType.InputClause,
        cssClasses: "decision-table--input",
        isRowIndexColumn: false,
      })
    );

    const outputColumns: ReactTable.Column<ROWTYPE>[] = (decisionTableExpression.output ?? []).map(
      (outputClause, outputIndex) => ({
        accessor: outputClause.id ?? generateUuid(),
        id: outputClause.id,
        label: outputClause.name,
        dataType: outputClause.dataType,
        width: outputClause.width ?? DECISION_TABLE_OUTPUT_MIN_WIDTH,
        setWidth: setOutputColumnWidth(outputIndex),
        minWidth: DECISION_TABLE_OUTPUT_MIN_WIDTH,
        groupType: DecisionTableColumnType.OutputClause,
        cssClasses: "decision-table--output",
        isRowIndexColumn: false,
      })
    );

    const annotationColumns: ReactTable.Column<ROWTYPE>[] = (decisionTableExpression.annotations ?? []).map(
      (annotation, annotationIndex) => {
        const annotationId = generateUuid();
        return {
          accessor: annotationId,
          id: annotationId,
          label: annotation.name,
          width: annotation.width ?? DECISION_TABLE_ANNOTATION_MIN_WIDTH,
          setWidth: setAnnotationColumnWidth(annotationIndex),
          minWidth: DECISION_TABLE_ANNOTATION_MIN_WIDTH,
          isInlineEditable: true,
          groupType: DecisionTableColumnType.Annotation,
          cssClasses: "decision-table--annotation",
          isRowIndexColumn: false,
          dataType: undefined as any,
        };
      }
    );

    const outputSection = {
      groupType: DecisionTableColumnType.OutputClause,
      id: "Outputs",
      accessor: "decision-table-expression" as any, // FIXME: Tiago -> ?
      label: decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME,
      dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
      cssClasses: "decision-table--output",
      isRowIndexColumn: false,
      columns: outputColumns,
      width: undefined,
    };

    const outputSectionTwo = {
      groupType: DecisionTableColumnType.OutputClause,
      id: "OutputsTwo",
      accessor: "decision-table-expression" as any, // FIXME: Tiago -> ?
      label: decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME,
      dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
      cssClasses: "decision-table--output",
      isRowIndexColumn: false,
      columns: [{
        accessor: "abc",
        id: "abc",
        label: "abc",
        dataType: DmnBuiltInDataType.Undefined,
        width: DECISION_TABLE_OUTPUT_MIN_WIDTH,
        minWidth: DECISION_TABLE_OUTPUT_MIN_WIDTH,
        groupType: DecisionTableColumnType.OutputClause,
        cssClasses: "decision-table--output",
        isRowIndexColumn: false,
      },
      {
        accessor: "efg",
        id: "efg",
        label: "efg",
        dataType: DmnBuiltInDataType.Undefined,
        width: DECISION_TABLE_OUTPUT_MIN_WIDTH,
        minWidth: DECISION_TABLE_OUTPUT_MIN_WIDTH,
        groupType: DecisionTableColumnType.OutputClause,
        cssClasses: "decision-table--output",
        isRowIndexColumn: false,
      }],
      width: undefined,
    };

    const outputSectionParent = {
      groupType: DecisionTableColumnType.OutputClause,
      id: "OutputsParent",
      accessor: "decision-table-expression" as any, // FIXME: Tiago -> ?
      label: decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME,
      dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,
      cssClasses: "decision-table--output",
      isRowIndexColumn: false,
      width: undefined,
      columns: [outputSection, outputSectionTwo],
    };

    return [...inputColumns, outputSectionParent, ...annotationColumns];
```