### PR TITLE
Fix: GitHub Action - DMN dev deployment-form-webapp

### DIFF
--- a/packages/dmn-dev-deployment-form-webapp/src/DmnFormPage.tsx
+++ b/packages/dmn-dev-deployment-form-webapp/src/DmnFormPage.tsx
@@ -61,7 +61,7 @@ export function DmnFormPage(props: Props) {
       });
 
       setFormOutputs((previousOutputs: DecisionResult[]) => {
-        const differences = extractDifferences(formOutputs, previousOutputs);
+        const [differences] = extractDifferences([formOutputs], [previousOutputs]);
         if (differences?.length !== 0) {
           setFormOutputDiffs(differences);
         }


### PR DESCRIPTION
The https://github.com/tiagobento/kie-tools/pull/91 broke the CI due to a change in the `extractDifference` method.