### PR TITLE
Fix an issue related about expression not set while changing decision nodes in BEE

### DIFF
--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -15,6 +15,7 @@
  */
 package org.kie.workbench.common.dmn.client.editors.expressions;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -355,16 +356,23 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     DomainObject findDomainObject(final String uuid) {
 
         if (innerExpressionMatches(uuid)) {
-            return (DomainObject) hasExpression;
+            return (DomainObject) getHasExpression();
         } else if (businessKnowledgeModelMatches(uuid)) {
             return getBusinessKnowledgeModel();
         } else {
-            final Optional<DomainObject> domainObject = hasExpression.getExpression().findDomainObject(uuid);
+            return findDomainObjectInCurrentExpression(uuid);
+        }
+    }
+
+    DomainObject findDomainObjectInCurrentExpression(final String uuid) {
+
+        if (!Objects.isNull(getHasExpression().getExpression())) {
+            final Optional<DomainObject> domainObject = getHasExpression().getExpression().findDomainObject(uuid);
             if (domainObject.isPresent()) {
                 return domainObject.get();
             }
-            return new NOPDomainObject();
         }
+        return new NOPDomainObject();
     }
 
     BusinessKnowledgeModel getBusinessKnowledgeModel() {
@@ -489,6 +497,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
     /**
      * It executes a given expression command. Before executing it, it creates and UNDO command with the current model
      * status. Statement ordering matters: the UNDO command MUST be called before executing the expression command change.
+     *
      * @param expressionCommand
      */
     void executeUndoableExpressionCommand(final FillExpressionCommand expressionCommand) {


### PR DESCRIPTION
Bug found by @ljmotta 

How to reproduce it:
1. Add a Decision node
2. Go to BEE
3. Add a Literal Expression
4. Type anything 
5. Go back to canvas
6. Add another Decision node
7. Try to go to BEE again
8. fail

VIDEO:

https://user-images.githubusercontent.com/7305741/229219639-a8200d45-e277-4fcc-be14-eac25d571ffd.mov

