### PR TITLE
Click in header not loading properties panel

### DIFF
--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextEntryExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextEntryExpressionCell.tsx
@@ -21,23 +21,24 @@ import {
   ContextExpressionDefinitionEntry,
   ExpressionDefinitionLogicType,
 } from "../../api";
-import * as _ from "lodash";
 import {
   NestedExpressionDispatchContextProvider,
   useBoxedExpressionEditorDispatch,
 } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionContainer";
 
 export interface ContextEntryExpressionCellProps {
   // This name ('data') can't change, as this is used on "cellComponentByColumnAccessor".
   data: readonly ContextExpressionDefinitionEntry[];
   rowIndex: number;
+  columnIndex: number;
 }
 
 export const ContextEntryExpressionCell: React.FunctionComponent<ContextEntryExpressionCellProps> = ({
   data: contextEntries,
   rowIndex,
+  columnIndex,
 }) => {
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
@@ -60,6 +61,8 @@ export const ContextEntryExpressionCell: React.FunctionComponent<ContextEntryExp
         expression={contextEntries[rowIndex]?.entryExpression}
         isResetSupported={true}
         isNested={true}
+        rowIndex={rowIndex}
+        columnIndex={columnIndex}
       />
     </NestedExpressionDispatchContextProvider>
   );

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextEntryInfoCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextEntryInfoCell.tsx
@@ -16,13 +16,14 @@
 
 import { ContextExpressionDefinitionEntry, DmnBuiltInDataType, ExpressionDefinition } from "../../api";
 import * as React from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import * as _ from "lodash";
 import { useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
 import { DEFAULT_EXPRESSION_NAME, ExpressionDefinitionHeaderMenu } from "../ExpressionDefinitionHeaderMenu";
 import "./ContextEntryInfoCell.css";
 import { useCellWidthToFitDataRef } from "../../resizing/BeeTableCellWidthToFitDataContext";
 import { getCanvasFont, getTextWidth } from "../../resizing/WidthsToFitData";
+import { useBoxedExpressionEditor } from "../../expressions/BoxedExpressionEditor/BoxedExpressionEditorContext";
 
 export interface ContextEntryInfoCellProps {
   // This name ('data') can't change, as this is used on "cellComponentByColumnAccessor".
@@ -86,12 +87,20 @@ export const ContextEntryInfoCell: React.FunctionComponent<ContextEntryInfoCellP
     )
   );
 
-  useBeeTableSelectableCellRef(
+  const { isActive } = useBeeTableSelectableCellRef(
     rowIndex,
     columnIndex,
     undefined,
     useCallback(() => `${entryInfo.name} (${entryInfo.dataType})`, [entryInfo.dataType, entryInfo.name])
   );
+
+  const { beeGwtService } = useBoxedExpressionEditor();
+
+  useEffect(() => {
+    if (isActive) {
+      beeGwtService?.selectObject(entryInfo.id);
+    }
+  }, [beeGwtService, entryInfo, isActive]);
 
   const renderEntryDefinition = useCallback(
     (args: { additionalCssClass?: string }) => (

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -118,7 +118,7 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
   const beeTableColumns = useMemo<ReactTable.Column<ROWTYPE>[]>(() => {
     return [
       {
-        accessor: "context-expression" as any, // FIXME: Tiago -> ?
+        accessor: contextExpression.id as any, // FIXME: Tiago -> ?
         label: contextExpression.name ?? DEFAULT_EXPRESSION_NAME,
         isRowIndexColumn: false,
         dataType: contextExpression.dataType ?? CONTEXT_ENTRY_DEFAULT_DATA_TYPE,

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -205,7 +205,12 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
   const beeTableAdditionalRow = useMemo(() => {
     return [
       <ContextResultInfoCell key={"context-result-info"} />,
-      <ContextResultExpressionCell key={"context-result-expression"} contextExpression={contextExpression} />,
+      <ContextResultExpressionCell
+        key={"context-result-expression"}
+        contextExpression={contextExpression}
+        rowIndex={0}
+        columnIndex={0}
+      />,
     ];
   }, [contextExpression]);
 

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextResultExpressionCell.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { ContextExpressionDefinition } from "../../api";
 import {
   useBoxedExpressionEditorDispatch,
@@ -7,7 +7,11 @@ import {
 } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
 import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionContainer";
 
-export function ContextResultExpressionCell(props: { contextExpression: ContextExpressionDefinition }) {
+export function ContextResultExpressionCell(props: {
+  contextExpression: ContextExpressionDefinition;
+  rowIndex: number;
+  columnIndex: number;
+}) {
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
   const onSetExpression = useCallback(
@@ -22,7 +26,13 @@ export function ContextResultExpressionCell(props: { contextExpression: ContextE
 
   return (
     <NestedExpressionDispatchContextProvider onSetExpression={onSetExpression}>
-      <ExpressionContainer expression={props.contextExpression.result} isResetSupported={true} isNested={true} />
+      <ExpressionContainer
+        expression={props.contextExpression.result}
+        isResetSupported={true}
+        isNested={true}
+        rowIndex={props.rowIndex}
+        columnIndex={props.columnIndex}
+      />
     </NestedExpressionDispatchContextProvider>
   );
 }

--- a/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/DecisionTableExpression/DecisionTableExpression.tsx
@@ -254,7 +254,7 @@ export function DecisionTableExpression(
 
     const outputSection = {
       groupType: DecisionTableColumnType.OutputClause,
-      id: "Outputs",
+      id: decisionTableExpression.id,
       accessor: "decision-table-expression" as any, // FIXME: Tiago -> ?
       label: decisionTableExpression.name ?? DEFAULT_EXPRESSION_NAME,
       dataType: decisionTableExpression.dataType ?? DmnBuiltInDataType.Undefined,

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionContainer.tsx
@@ -14,33 +14,43 @@
  * limitations under the License.
  */
 
-import { DmnBuiltInDataType, ExpressionDefinition, ExpressionDefinitionLogicType, generateUuid } from "../../api";
+import { ExpressionDefinition, ExpressionDefinitionLogicType, generateUuid } from "../../api";
 import * as React from "react";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { ExpressionDefinitionLogicTypeSelector } from "./ExpressionDefinitionLogicTypeSelector";
-import * as _ from "lodash";
 import {
   useBoxedExpressionEditor,
   useBoxedExpressionEditorDispatch,
 } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
-import { useNestedExpressionContainer } from "../../resizing/NestedExpressionContainerContext";
+import { useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
 
 export interface ExpressionContainerProps {
   expression: ExpressionDefinition;
   isNested: boolean;
   isResetSupported: boolean;
+  rowIndex: number;
+  columnIndex: number;
 }
 
 export const ExpressionContainer: React.FunctionComponent<ExpressionContainerProps> = ({
   expression,
   isNested,
   isResetSupported,
+  rowIndex,
+  columnIndex,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const { beeGwtService } = useBoxedExpressionEditor();
   const { setExpression } = useBoxedExpressionEditorDispatch();
+  const { isActive } = useBeeTableSelectableCellRef(rowIndex, columnIndex, undefined);
+
+  useEffect(() => {
+    if (isActive) {
+      beeGwtService?.selectObject("");
+    }
+  }, [beeGwtService, isActive]);
 
   const onLogicTypeSelected = useCallback(
     (logicType) => {

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionLogicTypeSelector/ExpressionDefinitionLogicTypeSelector.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionLogicTypeSelector/ExpressionDefinitionLogicTypeSelector.tsx
@@ -26,7 +26,6 @@ import { CutIcon } from "@patternfly/react-icons/dist/js/icons/cut-icon";
 import { ListIcon } from "@patternfly/react-icons/dist/js/icons/list-icon";
 import { PasteIcon } from "@patternfly/react-icons/dist/js/icons/paste-icon";
 import { TableIcon } from "@patternfly/react-icons/dist/js/icons/table-icon";
-import _ from "lodash";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ExpressionDefinition, ExpressionDefinitionLogicType, generateUuid } from "../../../api";

--- a/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionRoot.tsx
+++ b/packages/boxed-expression-component/src/expressions/ExpressionDefinitionRoot/ExpressionDefinitionRoot.tsx
@@ -40,7 +40,13 @@ export function ExpressionDefinitionRoot({
           <span className="expression-type">({expression.logicType})</span>
         </div>
 
-        <ExpressionContainer expression={expression} isResetSupported={isResetSupported} isNested={false} />
+        <ExpressionContainer
+          expression={expression}
+          isResetSupported={isResetSupported}
+          isNested={false}
+          rowIndex={0}
+          columnIndex={0}
+        />
       </div>
     </ResizingWidthsContextProvider>
   );

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
@@ -182,7 +182,7 @@ export function FeelFunctionExpression({
   );
 }
 
-export function FeelFunctionImplementationCell({ data, rowIndex }: BeeTableCellProps<FEEL_ROWTYPE>) {
+export function FeelFunctionImplementationCell({ data, rowIndex, columnIndex }: BeeTableCellProps<FEEL_ROWTYPE>) {
   const functionExpression = data[rowIndex].functionExpression as FeelFunctionExpressionDefinition;
 
   const { setExpression } = useBoxedExpressionEditorDispatch();
@@ -199,7 +199,13 @@ export function FeelFunctionImplementationCell({ data, rowIndex }: BeeTableCellP
 
   return (
     <NestedExpressionDispatchContextProvider onSetExpression={onSetExpression}>
-      <ExpressionContainer expression={functionExpression.expression} isResetSupported={true} isNested={true} />
+      <ExpressionContainer
+        expression={functionExpression.expression}
+        isResetSupported={true}
+        isNested={true}
+        rowIndex={rowIndex}
+        columnIndex={columnIndex}
+      />
     </NestedExpressionDispatchContextProvider>
   );
 }

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/FeelFunctionExpression.tsx
@@ -65,7 +65,7 @@ export function FeelFunctionExpression({
     return [
       {
         label: functionExpression.name ?? DEFAULT_EXPRESSION_NAME,
-        accessor: "function-expression" as any, // FIXME: Tiago -> ?
+        accessor: functionExpression.id as any, // FIXME: Tiago -> ?
         dataType: functionExpression.dataType ?? DmnBuiltInDataType.Undefined,
         isRowIndexColumn: false,
         width: undefined,

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -80,7 +80,7 @@ export function JavaFunctionExpression({
     return [
       {
         label: functionExpression.name ?? DEFAULT_EXPRESSION_NAME,
-        accessor: "function-expression" as any, // FIXME: Tiago -> ?
+        accessor: functionExpression.id as any, // FIXME: Tiago -> ?
         dataType: functionExpression.dataType ?? DmnBuiltInDataType.Undefined,
         isRowIndexColumn: false,
         width: undefined,

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
@@ -69,7 +69,7 @@ export function PmmlFunctionExpression({
     return [
       {
         label: functionExpression.name ?? DEFAULT_EXPRESSION_NAME,
-        accessor: "function-expression" as any, // FIXME: Tiago -> ?
+        accessor: functionExpression.id as any, // FIXME: Tiago -> ?
         dataType: functionExpression.dataType ?? DmnBuiltInDataType.Undefined,
         isRowIndexColumn: false,
         width: undefined,

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/ArgumentEntryExpressionCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/ArgumentEntryExpressionCell.tsx
@@ -32,11 +32,13 @@ export interface ArgumentEntryExpressionCellProps {
   // This name ('data') can't change, as this is used on "cellComponentByColumnAccessor".
   data: readonly ContextExpressionDefinitionEntry[];
   rowIndex: number;
+  columnIndex: number;
 }
 
 export const ArgumentEntryExpressionCell: React.FunctionComponent<ArgumentEntryExpressionCellProps> = ({
   data: argumentEntries,
   rowIndex,
+  columnIndex,
 }) => {
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
@@ -59,6 +61,8 @@ export const ArgumentEntryExpressionCell: React.FunctionComponent<ArgumentEntryE
         expression={argumentEntries[rowIndex]?.entryExpression}
         isResetSupported={true}
         isNested={true}
+        rowIndex={rowIndex}
+        columnIndex={columnIndex}
       />
     </NestedExpressionDispatchContextProvider>
   );

--- a/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/InvocationExpression/InvocationExpression.tsx
@@ -124,7 +124,7 @@ export function InvocationExpression(invocationExpression: InvocationExpressionD
     () => [
       {
         label: invocationExpression.name ?? DEFAULT_EXPRESSION_NAME,
-        accessor: "invocation-expression" as keyof ROWTYPE,
+        accessor: invocationExpression.id as keyof ROWTYPE,
         dataType: invocationExpression.dataType ?? INVOCATION_EXPRESSION_DEFAULT_PARAMETER_DATA_TYPE,
         isRowIndexColumn: false,
         width: undefined,

--- a/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ListExpression/ListExpression.tsx
@@ -34,7 +34,10 @@ import { useNestedExpressionContainerWithNestedExpressions } from "../../resizin
 import { NestedExpressionContainerContext } from "../../resizing/NestedExpressionContainerContext";
 import { LIST_EXPRESSION_EXTRA_WIDTH, LIST_EXPRESSION_ITEM_MIN_WIDTH } from "../../resizing/WidthConstants";
 import { BeeTable, BeeTableColumnUpdate } from "../../table/BeeTable";
-import { useBoxedExpressionEditorDispatch } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
+import {
+  useBoxedExpressionEditor,
+  useBoxedExpressionEditorDispatch,
+} from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
 import "./ListExpression.css";
 import { ListItemCell } from "./ListItemCell";
@@ -45,6 +48,7 @@ export type ROWTYPE = ContextExpressionDefinitionEntry;
 export function ListExpression(listExpression: ListExpressionDefinition & { isNested: boolean }) {
   const { i18n } = useBoxedExpressionEditorI18n();
   const { setExpression } = useBoxedExpressionEditorDispatch();
+  const { decisionNodeId } = useBoxedExpressionEditor();
 
   /// //////////////////////////////////////////////////////
   /// ///////////// RESIZING WIDTHS ////////////////////////
@@ -93,7 +97,7 @@ export function ListExpression(listExpression: ListExpressionDefinition & { isNe
   const beeTableColumns = useMemo<ReactTable.Column<ROWTYPE>[]>(
     () => [
       {
-        accessor: "list" as any,
+        accessor: decisionNodeId as any,
         label: listExpression.name ?? DEFAULT_EXPRESSION_NAME,
         dataType: listExpression.dataType,
         isRowIndexColumn: false,
@@ -110,7 +114,7 @@ export function ListExpression(listExpression: ListExpressionDefinition & { isNe
 
   const cellComponentByColumnAccessor: BeeTableProps<ROWTYPE>["cellComponentByColumnAccessor"] = useMemo(
     () => ({
-      list: ListItemCell,
+      [decisionNodeId]: ListItemCell,
     }),
     []
   );

--- a/packages/boxed-expression-component/src/expressions/ListExpression/ListItemCell.tsx
+++ b/packages/boxed-expression-component/src/expressions/ListExpression/ListItemCell.tsx
@@ -8,7 +8,7 @@ import {
 import { ExpressionContainer } from "../ExpressionDefinitionRoot/ExpressionContainer";
 import { ROWTYPE } from "./ListExpression";
 
-export function ListItemCell({ rowIndex, data: items }: BeeTableCellProps<ROWTYPE>) {
+export function ListItemCell({ rowIndex, data: items, columnIndex }: BeeTableCellProps<ROWTYPE>) {
   const { setExpression } = useBoxedExpressionEditorDispatch();
 
   const onSetExpression = useCallback(
@@ -26,7 +26,13 @@ export function ListItemCell({ rowIndex, data: items }: BeeTableCellProps<ROWTYP
 
   return (
     <NestedExpressionDispatchContextProvider onSetExpression={onSetExpression}>
-      <ExpressionContainer expression={items[rowIndex]?.entryExpression} isResetSupported={true} isNested={true} />
+      <ExpressionContainer
+        expression={items[rowIndex]?.entryExpression}
+        isResetSupported={true}
+        isNested={true}
+        rowIndex={rowIndex}
+        columnIndex={columnIndex}
+      />
     </NestedExpressionDispatchContextProvider>
   );
 }

--- a/packages/boxed-expression-component/src/expressions/LiteralExpression/LiteralExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/LiteralExpression/LiteralExpression.tsx
@@ -23,7 +23,10 @@ import { LITERAL_EXPRESSION_EXTRA_WIDTH, LITERAL_EXPRESSION_MIN_WIDTH } from "..
 import { BeeTable, BeeTableCellUpdate, BeeTableColumnUpdate, BeeTableRef } from "../../table/BeeTable";
 import { usePublishedBeeTableResizableColumns } from "../../resizing/BeeTableResizableColumnsContext";
 import { useBeeTableCoordinates, useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
-import { useBoxedExpressionEditorDispatch } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
+import {
+  useBoxedExpressionEditor,
+  useBoxedExpressionEditorDispatch,
+} from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
 import "./LiteralExpression.css";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
 import { ResizerStopBehavior } from "../../resizing/ResizingWidthsContext";
@@ -32,6 +35,7 @@ type ROWTYPE = any;
 
 export function LiteralExpression(literalExpression: LiteralExpressionDefinition & { isNested: boolean }) {
   const { setExpression } = useBoxedExpressionEditorDispatch();
+  const { decisionNodeId } = useBoxedExpressionEditor();
 
   const getValue = useCallback(() => {
     return literalExpression.content ?? "";
@@ -125,7 +129,7 @@ export function LiteralExpression(literalExpression: LiteralExpressionDefinition
   const beeTableColumns = useMemo<ReactTable.Column<ROWTYPE>[]>(() => {
     return [
       {
-        accessor: "literal-expression" as any, // FIXME: Tiago -> No bueno.
+        accessor: decisionNodeId as any, // FIXME: Tiago -> No bueno.
         label: literalExpression.name ?? DEFAULT_EXPRESSION_NAME,
         isRowIndexColumn: false,
         dataType: literalExpression.dataType,
@@ -137,16 +141,12 @@ export function LiteralExpression(literalExpression: LiteralExpressionDefinition
   }, [literalExpression.dataType, literalExpression.name, literalExpression.width, minWidth, setWidth]);
 
   const beeTableRows = useMemo<ROWTYPE[]>(() => {
-    return [{ "literal-expression": { content: literalExpression.content ?? "", id: literalExpression.id } }];
+    return [{ [decisionNodeId]: { content: literalExpression.content ?? "", id: literalExpression.id } }];
   }, [literalExpression]);
 
   const beeTableHeaderVisibility = useMemo(() => {
     return literalExpression.isNested ? BeeTableHeaderVisibility.None : BeeTableHeaderVisibility.AllLevels;
   }, [literalExpression.isNested]);
-
-  const getColumnKey = useCallback((column: ReactTable.Column<ROWTYPE>) => {
-    return column.label;
-  }, []);
 
   const getRowKey = useCallback((row: ReactTable.Row<ROWTYPE>) => {
     return row.id;
@@ -163,7 +163,6 @@ export function LiteralExpression(literalExpression: LiteralExpressionDefinition
         <BeeTable
           resizerStopBehavior={ResizerStopBehavior.SET_WIDTH_WHEN_SMALLER}
           forwardRef={beeTableRef}
-          getColumnKey={getColumnKey}
           getRowKey={getRowKey}
           columns={beeTableColumns}
           rows={beeTableRows}

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableHeader.tsx
@@ -16,7 +16,7 @@
 
 import * as _ from "lodash";
 import * as React from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import * as ReactTable from "react-table";
 import { DmnBuiltInDataType, BeeTableHeaderVisibility, ExpressionDefinition } from "../../api";
 import { useBoxedExpressionEditor } from "../../expressions/BoxedExpressionEditor/BoxedExpressionEditorContext";
@@ -27,7 +27,6 @@ import { ResizerStopBehavior } from "../../resizing/ResizingWidthsContext";
 import { getCanvasFont, getTextWidth } from "../../resizing/WidthsToFitData";
 import { BeeTableThController } from "./BeeTableThController";
 import { assertUnreachable } from "../../expressions/ExpressionDefinitionRoot/ExpressionDefinitionLogicTypeSelector";
-import { SelectionPart, useBeeTableSelectionDispatch } from "../../selection/BeeTableSelectionContext";
 
 export interface BeeTableColumnUpdate<R extends object> {
   dataType: DmnBuiltInDataType;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -428,11 +428,6 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                 .orElse(Optional.empty());
     }
 
-        final DomainObjectSelectionEvent event = new DomainObjectSelectionEvent(sessionManager.getCurrentSession().getCanvasHandler(),
-                                                                                domainObject);
-        this.domainObjectSelectionEvent.fire(event);
-    }
-
     private Optional<CanvasHandler> getCanvasHandler() {
         final Optional<ClientSession> session = Optional.ofNullable(sessionManager.getCurrentSession());
         return session.map(ClientSession::getCanvasHandler);

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -356,7 +356,7 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
     DomainObject findDomainObject(final String uuid) {
 
-        if (innerExpressionMatches(uuid)) {
+        if (currentDomainObjectMatches(uuid)) {
             return (DomainObject) getHasExpression();
         } else if (businessKnowledgeModelMatches(uuid)) {
             return getBusinessKnowledgeModel();
@@ -371,6 +371,8 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
             final Optional<DomainObject> domainObject = getHasExpression().getExpression().findDomainObject(uuid);
             if (domainObject.isPresent()) {
                 return domainObject.get();
+            } else if (innerExpressionMatches(uuid)) {
+                return (DomainObject) getHasExpression();
             }
         }
         return new NOPDomainObject();
@@ -380,9 +382,16 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
         return ((BusinessKnowledgeModel) hasExpression.getExpression().asDMNModelInstrumentedBase().getParent());
     }
 
+    boolean currentDomainObjectMatches(final String uuid) {
+        return getHasExpression() instanceof DomainObject
+                && matches(((DomainObject) getHasExpression()), uuid);
+    }
+
     boolean innerExpressionMatches(final String uuid) {
-        return hasExpression instanceof DomainObject
-                && matches(((DomainObject) hasExpression), uuid);
+
+        return getHasExpression() instanceof DomainObject
+                && !Objects.isNull(getHasExpression().getExpression())
+                && Objects.equals(getHasExpression().getExpression().getId().getValue(), uuid);
     }
 
     boolean businessKnowledgeModelMatches(final String uuid) {
@@ -417,6 +426,11 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
                             .findFirst();
                 })
                 .orElse(Optional.empty());
+    }
+
+        final DomainObjectSelectionEvent event = new DomainObjectSelectionEvent(sessionManager.getCurrentSession().getCanvasHandler(),
+                                                                                domainObject);
+        this.domainObjectSelectionEvent.fire(event);
     }
 
     private Optional<CanvasHandler> getCanvasHandler() {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -43,6 +43,7 @@ import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
 import org.kie.workbench.common.dmn.api.definition.model.ItemDefinition;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
+import org.kie.workbench.common.dmn.api.property.dmn.Id;
 import org.kie.workbench.common.dmn.api.property.dmn.Name;
 import org.kie.workbench.common.dmn.api.property.dmn.types.BuiltInType;
 import org.kie.workbench.common.dmn.client.commands.factory.DefaultCanvasCommandFactory;
@@ -281,31 +282,31 @@ public class ExpressionEditorViewImplTest {
         doReturn(viewportMediators).when(viewport).getMediators();
         doReturn(gridPanelElement).when(gridPanel).getElement();
         doReturn(Optional.of(editor)).when(editorDefinition).getEditor(any(GridCellTuple.class),
-                                                                       any(Optional.class),
-                                                                       any(HasExpression.class),
-                                                                       any(Optional.class),
-                                                                       anyBoolean(),
-                                                                       anyInt());
+                any(Optional.class),
+                any(HasExpression.class),
+                any(Optional.class),
+                anyBoolean(),
+                anyInt());
         doReturn(new BaseGridData()).when(editor).getModel();
 
         this.view = spy(new ExpressionEditorViewImpl(returnToLink,
-                                                     returnToDRGLabel,
-                                                     expressionName,
-                                                     expressionType,
-                                                     gridPanelContainer,
-                                                     translationService,
-                                                     listSelector,
-                                                     sessionManager,
-                                                     sessionCommandManager,
-                                                     canvasCommandFactory,
-                                                     expressionEditorDefinitionsSupplier,
-                                                     refreshFormPropertiesEvent,
-                                                     domainObjectSelectionEvent,
-                                                     editorSelectedEvent,
-                                                     dataTypePageActiveEvent,
-                                                     pmmlDocumentMetadataProvider,
-                                                     definitionUtils,
-                                                     itemDefinitionUtils));
+                returnToDRGLabel,
+                expressionName,
+                expressionType,
+                gridPanelContainer,
+                translationService,
+                listSelector,
+                sessionManager,
+                sessionCommandManager,
+                canvasCommandFactory,
+                expressionEditorDefinitionsSupplier,
+                refreshFormPropertiesEvent,
+                domainObjectSelectionEvent,
+                editorSelectedEvent,
+                dataTypePageActiveEvent,
+                pmmlDocumentMetadataProvider,
+                definitionUtils,
+                itemDefinitionUtils));
         view.init(presenter);
         view.bind(session);
 
@@ -323,22 +324,22 @@ public class ExpressionEditorViewImplTest {
         when(undefinedExpressionEditorDefinition.getType()).thenReturn(UNDEFINED);
         when(undefinedExpressionEditor.getModel()).thenReturn(new BaseGridData());
         when(undefinedExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
-                                                           any(Optional.class),
-                                                           any(HasExpression.class),
-                                                           any(Optional.class),
-                                                           anyBoolean(),
-                                                           anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
+                any(Optional.class),
+                any(HasExpression.class),
+                any(Optional.class),
+                anyBoolean(),
+                anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
 
         when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(new LiteralExpression()));
         when(literalExpressionEditorDefinition.getName()).thenReturn(LITERAL_EXPRESSION.getText());
         when(literalExpressionEditorDefinition.getType()).thenReturn(LITERAL_EXPRESSION);
         when(literalExpressionEditor.getModel()).thenReturn(new BaseGridData());
         when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
-                                                         any(Optional.class),
-                                                         any(HasExpression.class),
-                                                         any(Optional.class),
-                                                         anyBoolean(),
-                                                         anyInt())).thenReturn(Optional.of(literalExpressionEditor));
+                any(Optional.class),
+                any(HasExpression.class),
+                any(Optional.class),
+                anyBoolean(),
+                anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 
         doAnswer((i) -> i.getArguments()[1]).when(translationService).format(Mockito.<String>any(), anyObject());
         doAnswer((i) -> i.getArguments()[0]).when(translationService).getTranslation(Mockito.<String>any());
@@ -360,18 +361,18 @@ public class ExpressionEditorViewImplTest {
         final Transform transform = transformArgumentCaptor.getValue();
 
         assertEquals(ExpressionEditorViewImpl.VP_SCALE,
-                     transform.getScaleX(),
-                     0.0);
+                transform.getScaleX(),
+                0.0);
         assertEquals(ExpressionEditorViewImpl.VP_SCALE,
-                     transform.getScaleY(),
-                     0.0);
+                transform.getScaleY(),
+                0.0);
 
         verify(gridPanel).addKeyDownHandler(any(BaseGridWidgetKeyboardHandler.class));
         verify(gridPanelContainer).clear();
         verify(gridPanelContainer).setWidget(gridPanel);
 
         verify(view, times(7)).addKeyboardOperation(any(BaseGridWidgetKeyboardHandler.class),
-                                                    keyboardOperationArgumentCaptor.capture());
+                keyboardOperationArgumentCaptor.capture());
         final List<KeyboardOperation> operations = keyboardOperationArgumentCaptor.getAllValues();
         assertThat(operations.get(0)).isInstanceOf(KeyboardOperationEditCell.class);
         assertThat(operations.get(1)).isInstanceOf(KeyboardOperationEscapeGridCell.class);
@@ -426,9 +427,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                           hasExpression,
-                           hasName,
-                           false);
+                hasExpression,
+                hasName,
+                false);
 
         verify(gridLayer).add(expressionContainerArgumentCaptor.capture());
         final ExpressionContainerGrid expressionContainer = (ExpressionContainerGrid) expressionContainerArgumentCaptor.getValue();
@@ -440,9 +441,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                           hasExpression,
-                           hasName,
-                           true);
+                hasExpression,
+                hasName,
+                true);
 
         verify(gridLayer).add(expressionContainerArgumentCaptor.capture());
         final ExpressionContainerGrid expressionContainer = (ExpressionContainerGrid) expressionContainerArgumentCaptor.getValue();
@@ -458,9 +459,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.of(hasNameMock);
 
         view.setExpression(NODE_UUID,
-                           hasExpression,
-                           hasName,
-                           false);
+                hasExpression,
+                hasName,
+                false);
 
         verify(expressionName).setTextContent(NAME);
     }
@@ -470,9 +471,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                           hasExpression,
-                           hasName,
-                           false);
+                hasExpression,
+                hasName,
+                false);
 
         verify(expressionName, never()).setTextContent(any(String.class));
     }
@@ -484,9 +485,9 @@ public class ExpressionEditorViewImplTest {
         when(hasExpression.getExpression()).thenReturn(expression);
 
         view.setExpression(NODE_UUID,
-                           hasExpression,
-                           hasName,
-                           false);
+                hasExpression,
+                hasName,
+                false);
 
         verify(expressionType).setTextContent(LITERAL_EXPRESSION.getText());
     }
@@ -496,9 +497,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                           hasExpression,
-                           hasName,
-                           false);
+                hasExpression,
+                hasName,
+                false);
 
         verify(expressionType).setTextContent("<" + UNDEFINED_EXPRESSION_DEFINITION_NAME + ">");
     }
@@ -530,9 +531,9 @@ public class ExpressionEditorViewImplTest {
     public void testEditingExpression() {
         final Optional<HasName> hasName = Optional.of(HasName.NOP);
         view.setExpression(NODE_UUID,
-                           hasExpression,
-                           hasName,
-                           false);
+                hasExpression,
+                hasName,
+                false);
 
         verify(view).setExpressionNameText(hasName);
     }
@@ -719,9 +720,9 @@ public class ExpressionEditorViewImplTest {
 
         verify(gridCache).removeExpressionGrid(NODE_UUID);
         verify(expressionContainerGrid).setExpression(NODE_UUID,
-                                                      hasExpression,
-                                                      hasName,
-                                                      false);
+                hasExpression,
+                hasName,
+                false);
     }
 
     @Test
@@ -800,7 +801,7 @@ public class ExpressionEditorViewImplTest {
         final String uuid = "someUuid";
         final DomainObject domainObject = mock(DomainObject.class);
 
-        doReturn(false).when(view).innerExpressionMatches(uuid);
+        doReturn(false).when(view).currentDomainObjectMatches(uuid);
         doReturn(false).when(view).businessKnowledgeModelMatches(uuid);
         doReturn(domainObject).when(view).findDomainObject(uuid);
 
@@ -815,7 +816,8 @@ public class ExpressionEditorViewImplTest {
         final String uuid = "someUuid";
         final BusinessKnowledgeModel bkm = mock(BusinessKnowledgeModel.class);
 
-        doReturn(false).when(view).innerExpressionMatches(uuid);
+        doReturn(false).when(view).currentDomainObjectMatches(uuid);
+        doReturn(false).when(view).innerExpressionMatches(eq(uuid));
         doReturn(true).when(view).businessKnowledgeModelMatches(uuid);
         doReturn(bkm).when(view).getBusinessKnowledgeModel();
 
@@ -829,7 +831,7 @@ public class ExpressionEditorViewImplTest {
 
         final String uuid = "someUuid";
 
-        doReturn(true).when(view).innerExpressionMatches(uuid);
+        doReturn(true).when(view).currentDomainObjectMatches(uuid);
 
         final DomainObject foundDomainObject = view.findDomainObject(uuid);
 
@@ -854,6 +856,7 @@ public class ExpressionEditorViewImplTest {
 
         when(expression.findDomainObject(uuid)).thenReturn(Optional.empty());
         when(hasExpression.getExpression()).thenReturn(expression);
+        doReturn(false).when(view).innerExpressionMatches(uuid);
 
         final DomainObject domainObject = view.findDomainObjectInCurrentExpression(uuid);
 
@@ -876,5 +879,42 @@ public class ExpressionEditorViewImplTest {
         verify(expression).findDomainObject(uuid);
         assertFalse(result instanceof NOPDomainObject);
         assertEquals(domainObject, result);
+    }
+
+    @Test
+    public void testInnerExpressionMatches() {
+
+        final String uuid = "uuid";
+        final Id id = new Id(uuid);
+        final Expression expression = mock(Expression.class);
+
+        when(expression.getId()).thenReturn(id);
+        when(hasExpression.getExpression()).thenReturn(expression);
+
+        assertTrue(view.innerExpressionMatches(uuid));
+    }
+
+    @Test
+    public void testInnerExpressionMatches_WhenDoesNot() {
+
+        final String uuid = "uuid";
+        final Id id = new Id(uuid);
+        final Expression expression = mock(Expression.class);
+
+        when(expression.getId()).thenReturn(id);
+        when(hasExpression.getExpression()).thenReturn(expression);
+
+        assertFalse(view.innerExpressionMatches("anotherUuid"));
+    }
+
+    @Test
+    public void testInnerExpressionMatches_WhenExpressionIsNull() {
+
+        final String uuid = "uuid";
+        final Id id = new Id(uuid);
+
+        when(hasExpression.getExpression()).thenReturn(null);
+
+        assertFalse(view.innerExpressionMatches(uuid));
     }
 }

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -911,7 +911,6 @@ public class ExpressionEditorViewImplTest {
     public void testInnerExpressionMatches_WhenExpressionIsNull() {
 
         final String uuid = "uuid";
-        final Id id = new Id(uuid);
 
         when(hasExpression.getExpression()).thenReturn(null);
 

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -282,31 +282,31 @@ public class ExpressionEditorViewImplTest {
         doReturn(viewportMediators).when(viewport).getMediators();
         doReturn(gridPanelElement).when(gridPanel).getElement();
         doReturn(Optional.of(editor)).when(editorDefinition).getEditor(any(GridCellTuple.class),
-                any(Optional.class),
-                any(HasExpression.class),
-                any(Optional.class),
-                anyBoolean(),
-                anyInt());
+                                                                       any(Optional.class),
+                                                                       any(HasExpression.class),
+                                                                       any(Optional.class),
+                                                                       anyBoolean(),
+                                                                       anyInt());
         doReturn(new BaseGridData()).when(editor).getModel();
 
         this.view = spy(new ExpressionEditorViewImpl(returnToLink,
-                returnToDRGLabel,
-                expressionName,
-                expressionType,
-                gridPanelContainer,
-                translationService,
-                listSelector,
-                sessionManager,
-                sessionCommandManager,
-                canvasCommandFactory,
-                expressionEditorDefinitionsSupplier,
-                refreshFormPropertiesEvent,
-                domainObjectSelectionEvent,
-                editorSelectedEvent,
-                dataTypePageActiveEvent,
-                pmmlDocumentMetadataProvider,
-                definitionUtils,
-                itemDefinitionUtils));
+                                                     returnToDRGLabel,
+                                                     expressionName,
+                                                     expressionType,
+                                                     gridPanelContainer,
+                                                     translationService,
+                                                     listSelector,
+                                                     sessionManager,
+                                                     sessionCommandManager,
+                                                     canvasCommandFactory,
+                                                     expressionEditorDefinitionsSupplier,
+                                                     refreshFormPropertiesEvent,
+                                                     domainObjectSelectionEvent,
+                                                     editorSelectedEvent,
+                                                     dataTypePageActiveEvent,
+                                                     pmmlDocumentMetadataProvider,
+                                                     definitionUtils,
+                                                     itemDefinitionUtils));
         view.init(presenter);
         view.bind(session);
 
@@ -324,22 +324,22 @@ public class ExpressionEditorViewImplTest {
         when(undefinedExpressionEditorDefinition.getType()).thenReturn(UNDEFINED);
         when(undefinedExpressionEditor.getModel()).thenReturn(new BaseGridData());
         when(undefinedExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
-                any(Optional.class),
-                any(HasExpression.class),
-                any(Optional.class),
-                anyBoolean(),
-                anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
+                                                           any(Optional.class),
+                                                           any(HasExpression.class),
+                                                           any(Optional.class),
+                                                           anyBoolean(),
+                                                           anyInt())).thenReturn(Optional.of(undefinedExpressionEditor));
 
         when(literalExpressionEditorDefinition.getModelClass()).thenReturn(Optional.of(new LiteralExpression()));
         when(literalExpressionEditorDefinition.getName()).thenReturn(LITERAL_EXPRESSION.getText());
         when(literalExpressionEditorDefinition.getType()).thenReturn(LITERAL_EXPRESSION);
         when(literalExpressionEditor.getModel()).thenReturn(new BaseGridData());
         when(literalExpressionEditorDefinition.getEditor(any(GridCellTuple.class),
-                any(Optional.class),
-                any(HasExpression.class),
-                any(Optional.class),
-                anyBoolean(),
-                anyInt())).thenReturn(Optional.of(literalExpressionEditor));
+                                                         any(Optional.class),
+                                                         any(HasExpression.class),
+                                                         any(Optional.class),
+                                                         anyBoolean(),
+                                                         anyInt())).thenReturn(Optional.of(literalExpressionEditor));
 
         doAnswer((i) -> i.getArguments()[1]).when(translationService).format(Mockito.<String>any(), anyObject());
         doAnswer((i) -> i.getArguments()[0]).when(translationService).getTranslation(Mockito.<String>any());
@@ -361,18 +361,18 @@ public class ExpressionEditorViewImplTest {
         final Transform transform = transformArgumentCaptor.getValue();
 
         assertEquals(ExpressionEditorViewImpl.VP_SCALE,
-                transform.getScaleX(),
-                0.0);
+                     transform.getScaleX(),
+                     0.0);
         assertEquals(ExpressionEditorViewImpl.VP_SCALE,
-                transform.getScaleY(),
-                0.0);
+                     transform.getScaleY(),
+                     0.0);
 
         verify(gridPanel).addKeyDownHandler(any(BaseGridWidgetKeyboardHandler.class));
         verify(gridPanelContainer).clear();
         verify(gridPanelContainer).setWidget(gridPanel);
 
         verify(view, times(7)).addKeyboardOperation(any(BaseGridWidgetKeyboardHandler.class),
-                keyboardOperationArgumentCaptor.capture());
+                                                    keyboardOperationArgumentCaptor.capture());
         final List<KeyboardOperation> operations = keyboardOperationArgumentCaptor.getAllValues();
         assertThat(operations.get(0)).isInstanceOf(KeyboardOperationEditCell.class);
         assertThat(operations.get(1)).isInstanceOf(KeyboardOperationEscapeGridCell.class);
@@ -427,9 +427,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                false);
+                           hasExpression,
+                           hasName,
+                           false);
 
         verify(gridLayer).add(expressionContainerArgumentCaptor.capture());
         final ExpressionContainerGrid expressionContainer = (ExpressionContainerGrid) expressionContainerArgumentCaptor.getValue();
@@ -441,9 +441,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                true);
+                           hasExpression,
+                           hasName,
+                           true);
 
         verify(gridLayer).add(expressionContainerArgumentCaptor.capture());
         final ExpressionContainerGrid expressionContainer = (ExpressionContainerGrid) expressionContainerArgumentCaptor.getValue();
@@ -459,9 +459,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.of(hasNameMock);
 
         view.setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                false);
+                           hasExpression,
+                           hasName,
+                           false);
 
         verify(expressionName).setTextContent(NAME);
     }
@@ -471,9 +471,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                false);
+                           hasExpression,
+                           hasName,
+                           false);
 
         verify(expressionName, never()).setTextContent(any(String.class));
     }
@@ -485,9 +485,9 @@ public class ExpressionEditorViewImplTest {
         when(hasExpression.getExpression()).thenReturn(expression);
 
         view.setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                false);
+                           hasExpression,
+                           hasName,
+                           false);
 
         verify(expressionType).setTextContent(LITERAL_EXPRESSION.getText());
     }
@@ -497,9 +497,9 @@ public class ExpressionEditorViewImplTest {
         final Optional<HasName> hasName = Optional.empty();
 
         view.setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                false);
+                           hasExpression,
+                           hasName,
+                           false);
 
         verify(expressionType).setTextContent("<" + UNDEFINED_EXPRESSION_DEFINITION_NAME + ">");
     }
@@ -531,9 +531,9 @@ public class ExpressionEditorViewImplTest {
     public void testEditingExpression() {
         final Optional<HasName> hasName = Optional.of(HasName.NOP);
         view.setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                false);
+                           hasExpression,
+                           hasName,
+                           false);
 
         verify(view).setExpressionNameText(hasName);
     }
@@ -720,9 +720,9 @@ public class ExpressionEditorViewImplTest {
 
         verify(gridCache).removeExpressionGrid(NODE_UUID);
         verify(expressionContainerGrid).setExpression(NODE_UUID,
-                hasExpression,
-                hasName,
-                false);
+                                                      hasExpression,
+                                                      hasName,
+                                                      false);
     }
 
     @Test


### PR DESCRIPTION
When a header of ContextExpression or the output column in DecisionTale are selected the properties panel was not being loaded.