### PR TITLE
Fix properties panel behavior for BKM and cells that does not have properties

### DIFF
--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import * as ReactTable from "react-table";
 import {
   BeeTableHeaderVisibility,
@@ -40,7 +40,10 @@ import {
 } from "../../resizing/WidthConstants";
 import { useBeeTableSelectableCellRef, useBeeTableCoordinates } from "../../selection/BeeTableSelectionContext";
 import { BeeTable, BeeTableColumnUpdate } from "../../table/BeeTable";
-import { useBoxedExpressionEditorDispatch } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
+import {
+  useBoxedExpressionEditor,
+  useBoxedExpressionEditorDispatch,
+} from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
 import { ContextEntryExpressionCell } from "./ContextEntryExpressionCell";
 import { ContextEntryInfoCell } from "./ContextEntryInfoCell";
@@ -208,8 +211,8 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
       <ContextResultExpressionCell
         key={"context-result-expression"}
         contextExpression={contextExpression}
-        rowIndex={0}
-        columnIndex={0}
+        rowIndex={1}
+        columnIndex={2}
       />,
     ];
   }, [contextExpression]);
@@ -334,12 +337,20 @@ export function ContextResultInfoCell() {
     return value;
   }, [value]);
 
-  useBeeTableSelectableCellRef(
+  const { isActive } = useBeeTableSelectableCellRef(
     containerCellCoordinates?.rowIndex ?? 0,
     containerCellCoordinates?.columnIndex ?? 0,
     undefined,
     getValue
   );
+
+  const { beeGwtService } = useBoxedExpressionEditor();
+
+  useEffect(() => {
+    if (isActive) {
+      beeGwtService?.selectObject("");
+    }
+  }, [beeGwtService, isActive]);
 
   return <div className="context-result">{value}</div>;
 }

--- a/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/ContextExpression/ContextExpression.tsx
@@ -211,7 +211,7 @@ export function ContextExpression(contextExpression: ContextExpressionDefinition
       <ContextResultExpressionCell
         key={"context-result-expression"}
         contextExpression={contextExpression}
-        rowIndex={1}
+        rowIndex={contextExpression.contextEntries.length}
         columnIndex={2}
       />,
     ];

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/JavaFunctionExpression.tsx
@@ -42,7 +42,10 @@ import {
 } from "../../resizing/WidthConstants";
 import { useBeeTableSelectableCellRef } from "../../selection/BeeTableSelectionContext";
 import { BeeTable, BeeTableCellUpdate, BeeTableColumnUpdate, BeeTableRef } from "../../table/BeeTable";
-import { useBoxedExpressionEditorDispatch } from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
+import {
+  useBoxedExpressionEditor,
+  useBoxedExpressionEditorDispatch,
+} from "../BoxedExpressionEditor/BoxedExpressionEditorContext";
 import { DEFAULT_EXPRESSION_NAME } from "../ExpressionDefinitionHeaderMenu";
 import { useFunctionExpressionControllerCell, useFunctionExpressionParametersColumnHeader } from "./FunctionExpression";
 import "./JavaFunctionExpression.css";
@@ -285,12 +288,20 @@ function JavaFunctionExpressionLabelCell(props: React.PropsWithChildren<BeeTable
     return props.data[props.rowIndex].label;
   }, [props.data, props.rowIndex]);
 
-  useBeeTableSelectableCellRef(
+  const { isActive } = useBeeTableSelectableCellRef(
     props.rowIndex,
     props.columnIndex,
     undefined,
     useCallback(() => label, [label])
   );
+
+  const { beeGwtService } = useBoxedExpressionEditor();
+
+  useEffect(() => {
+    if (isActive) {
+      beeGwtService?.selectObject("");
+    }
+  }, [beeGwtService, isActive]);
 
   const getParameterLabelHelp = useCallback((): React.ReactNode => {
     if (props.rowIndex === 1) {

--- a/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
+++ b/packages/boxed-expression-component/src/expressions/FunctionExpression/PmmlFunctionExpression.tsx
@@ -17,7 +17,7 @@
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core/dist/js/components/Select";
 import _ from "lodash";
 import * as React from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import * as ReactTable from "react-table";
 import {
   BeeTableCellProps,
@@ -247,12 +247,20 @@ function PmmlFunctionExpressionLabelCell(props: React.PropsWithChildren<BeeTable
     return props.data[props.rowIndex].label;
   }, [props.data, props.rowIndex]);
 
-  useBeeTableSelectableCellRef(
+  const { isActive } = useBeeTableSelectableCellRef(
     props.rowIndex,
     props.columnIndex,
     undefined,
     useCallback(() => label, [label])
   );
+
+  const { beeGwtService } = useBoxedExpressionEditor();
+
+  useEffect(() => {
+    if (isActive) {
+      beeGwtService?.selectObject("");
+    }
+  }, [beeGwtService, isActive]);
 
   return (
     <div className={"pmml-function-expression-label"}>

--- a/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
+++ b/packages/boxed-expression-component/src/selection/BeeTableSelectionContext.tsx
@@ -1071,5 +1071,6 @@ export function useBeeTableSelectableCell(
     cssClasses,
     onMouseDown,
     onDoubleClick,
+    isActive,
   };
 }

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTd.tsx
@@ -26,7 +26,9 @@ import {
   BeeTableCellCoordinates,
   BeeTableCoordinatesContextProvider,
   useBeeTableSelectableCell,
+  useBeeTableSelectableCellRef,
 } from "../../selection/BeeTableSelectionContext";
+import { useBoxedExpressionEditor } from "../../expressions/BoxedExpressionEditor/BoxedExpressionEditorContext";
 
 export interface BeeTableTdProps<R extends object> {
   // Individual cells are not immutable referecens, By referencing the row, we avoid multiple re-renders and bugs.
@@ -94,6 +96,16 @@ export function BeeTableTd<R extends object>({
     }
     return undefined;
   }, [column.isRowIndexColumn, rowIndexLabel]);
+
+  const { isActive } = useBeeTableSelectableCellRef(rowIndex, columnIndex, undefined);
+
+  const { beeGwtService } = useBoxedExpressionEditor();
+
+  useEffect(() => {
+    if (isActive && column.isRowIndexColumn) {
+      beeGwtService?.selectObject("");
+    }
+  }, [beeGwtService, isActive, column]);
 
   useEffect(() => {
     function onEnter(e: MouseEvent) {

--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
@@ -21,9 +21,10 @@ import * as ReactTable from "react-table";
 import {
   BeeTableCellCoordinates,
   BeeTableCoordinatesContextProvider,
-  useBeeTableSelectionDispatch,
+  useBeeTableSelectableCellRef,
 } from "../../selection/BeeTableSelectionContext";
 import { useBeeTableSelectableCell } from "../../selection/BeeTableSelectionContext";
+import { useBoxedExpressionEditor } from "../../expressions/BoxedExpressionEditor/BoxedExpressionEditorContext";
 
 export interface BeeTableThProps<R extends object> {
   groupType: string | undefined;
@@ -83,6 +84,16 @@ export function BeeTableTh<R extends object>({
     },
     [columnIndex, groupType, hoverInfo, onColumnAdded]
   );
+
+  const { isActive } = useBeeTableSelectableCellRef(rowIndex, columnIndex, undefined);
+
+  const { beeGwtService } = useBoxedExpressionEditor();
+
+  useEffect(() => {
+    if (isActive) {
+      beeGwtService?.selectObject("");
+    }
+  }, [beeGwtService, isActive]);
 
   const _thRef = useRef<HTMLTableCellElement>(null);
   const thRef = forwardRef ?? _thRef;

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImpl.java
@@ -400,8 +400,15 @@ public class ExpressionEditorViewImpl implements ExpressionEditorView {
 
     boolean businessKnowledgeModelMatches(final String uuid) {
 
-        return hasExpression.getExpression() instanceof FunctionDefinition
-                && matches(getBusinessKnowledgeModel(), uuid);
+        return getHasExpression().getExpression() instanceof FunctionDefinition
+                && (matches(getBusinessKnowledgeModel(), uuid) || encapsulatedLogicMatches(uuid));
+    }
+
+    boolean encapsulatedLogicMatches(final String uuid) {
+
+        final BusinessKnowledgeModel bkm = getBusinessKnowledgeModel();
+        return !Objects.isNull(bkm)
+                && Objects.equals(bkm.getEncapsulatedLogic().getId().getValue(), uuid);
     }
 
     void fireDomainObjectSelectionEvent(final DomainObject domainObject) {

--- a/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
+++ b/packages/stunner-editors/kie-wb-common-dmn/kie-wb-common-dmn-client/src/test/java/org/kie/workbench/common/dmn/client/editors/expressions/ExpressionEditorViewImplTest.java
@@ -41,6 +41,7 @@ import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.NOPDomainObject;
 import org.kie.workbench.common.dmn.api.definition.model.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.model.Expression;
+import org.kie.workbench.common.dmn.api.definition.model.FunctionDefinition;
 import org.kie.workbench.common.dmn.api.definition.model.ItemDefinition;
 import org.kie.workbench.common.dmn.api.definition.model.LiteralExpression;
 import org.kie.workbench.common.dmn.api.property.dmn.Id;
@@ -915,5 +916,93 @@ public class ExpressionEditorViewImplTest {
         when(hasExpression.getExpression()).thenReturn(null);
 
         assertFalse(view.innerExpressionMatches(uuid));
+    }
+
+    @Test
+    public void testBusinessKnowledgeModelMatches_WhenIsNotABkm() {
+
+        final FunctionDefinition functionDefinition = mock(FunctionDefinition.class);
+        when(hasExpression.getExpression()).thenReturn(functionDefinition);
+        doReturn(null).when(view).getBusinessKnowledgeModel();
+
+        assertFalse(view.businessKnowledgeModelMatches("someUuid"));
+    }
+
+    @Test
+    public void testBusinessKnowledgeModelMatches_WhenExpressionIsNotAFunctionDefinition() {
+
+        doReturn(null).when(view).getBusinessKnowledgeModel();
+
+        assertFalse(view.businessKnowledgeModelMatches("someUuid"));
+    }
+
+    @Test
+    public void testBusinessKnowledgeModelMatches_WhenDoesNotMatch() {
+
+        final FunctionDefinition functionDefinition = mock(FunctionDefinition.class);
+        final BusinessKnowledgeModel bkm = mock(BusinessKnowledgeModel.class);
+        final String someUuid = "uuid";
+        final Id id = new Id(someUuid);
+        when(bkm.getEncapsulatedLogic()).thenReturn(functionDefinition);
+        when(functionDefinition.getId()).thenReturn(id);
+        when(hasExpression.getExpression()).thenReturn(functionDefinition);
+
+        doReturn(bkm).when(view).getBusinessKnowledgeModel();
+
+        assertFalse(view.businessKnowledgeModelMatches("anotherUuid"));
+    }
+
+    @Test
+    public void testBusinessKnowledgeModelMatches_WhenMatches() {
+
+        final FunctionDefinition functionDefinition = mock(FunctionDefinition.class);
+        final BusinessKnowledgeModel bkm = mock(BusinessKnowledgeModel.class);
+        final String someUuid = "uuid";
+        final Id id = new Id(someUuid);
+        when(bkm.getEncapsulatedLogic()).thenReturn(functionDefinition);
+        when(functionDefinition.getId()).thenReturn(id);
+        when(hasExpression.getExpression()).thenReturn(functionDefinition);
+
+        doReturn(bkm).when(view).getBusinessKnowledgeModel();
+
+        assertTrue(view.businessKnowledgeModelMatches(someUuid));
+    }
+
+    @Test
+    public void testBusinessKnowledgeModelMatches_WhenEncapsulatedLogicMatches() {
+
+        final FunctionDefinition functionDefinition = mock(FunctionDefinition.class);
+        final BusinessKnowledgeModel bkm = mock(BusinessKnowledgeModel.class);
+        final String someUuid = "uuid";
+        final Id id = new Id(someUuid);
+        final String encapsulatedLogicUuid = "otherUuid";
+
+        when(bkm.getEncapsulatedLogic()).thenReturn(functionDefinition);
+        when(functionDefinition.getId()).thenReturn(id);
+        when(hasExpression.getExpression()).thenReturn(functionDefinition);
+
+        doReturn(true).when(view).encapsulatedLogicMatches(encapsulatedLogicUuid);
+        doReturn(bkm).when(view).getBusinessKnowledgeModel();
+
+        assertTrue(view.businessKnowledgeModelMatches(encapsulatedLogicUuid));
+    }
+
+    @Test
+    public void testBusinessKnowledgeModelMatches_WhenNothingMatches() {
+
+        final FunctionDefinition functionDefinition = mock(FunctionDefinition.class);
+        final BusinessKnowledgeModel bkm = mock(BusinessKnowledgeModel.class);
+        final String someUuid = "uuid";
+        final Id id = new Id(someUuid);
+        final String encapsulatedLogicUuid = "otherUuid";
+
+        when(bkm.getEncapsulatedLogic()).thenReturn(functionDefinition);
+        when(functionDefinition.getId()).thenReturn(id);
+        when(hasExpression.getExpression()).thenReturn(functionDefinition);
+
+        doReturn(false).when(view).encapsulatedLogicMatches(encapsulatedLogicUuid);
+        doReturn(bkm).when(view).getBusinessKnowledgeModel();
+
+        assertFalse(view.businessKnowledgeModelMatches(encapsulatedLogicUuid));
     }
 }


### PR DESCRIPTION
- Properties panel display logic for BKM in BEE
- Properties panel now is hidden when user clicks in a cell that does not have properties, like the behavior in old BEE