### PR TITLE
DMN Runner - sanity checks

### DIFF
--- a/packages/form-dmn/src/DmnForm.tsx
+++ b/packages/form-dmn/src/DmnForm.tsx
@@ -22,7 +22,7 @@ import { FormComponent, FormProps } from "@kie-tools/form";
 import { DmnAutoFieldProvider } from "./uniforms/DmnAutoFieldProvider";
 import { ExtendedServicesDmnJsonSchema } from "@kie-tools/extended-services-api";
 
-export type InputRow = Record<string, string>;
+export type InputRow = Record<string, any>;
 
 export function DmnForm(props: FormProps<InputRow, ExtendedServicesDmnJsonSchema>) {
   const i18n = useMemo(() => {

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContext.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContext.tsx
@@ -40,7 +40,6 @@ export interface DmnRunnerContextType {
 
 export interface DmnRunnerCallbacksContextType {
   setDmnRunnerContextProviderState: React.Dispatch<DmnRunnerProviderAction>;
-  onDeleteInputs: () => void;
   onRowAdded: (args: { beforeIndex: number }) => void;
   onRowDuplicated: (args: { rowIndex: number }) => void;
   onRowReset: (args: { rowIndex: number }) => void;

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContext.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContext.tsx
@@ -40,6 +40,7 @@ export interface DmnRunnerContextType {
 
 export interface DmnRunnerCallbacksContextType {
   setDmnRunnerContextProviderState: React.Dispatch<DmnRunnerProviderAction>;
+  onDeleteInputs: () => void;
   onRowAdded: (args: { beforeIndex: number }) => void;
   onRowDuplicated: (args: { rowIndex: number }) => void;
   onRowReset: (args: { rowIndex: number }) => void;

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -171,15 +171,6 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
   // Reset JSON Schema and PersistenceJson;
   useLayoutEffect(() => {
     setJsonSchema(undefined);
-    // dmnRunnerPersistenceJsonDispatcher({
-    //   updatePersistenceJsonDebouce,
-    //   workspaceFileRelativePath: props.workspaceFile.relativePath,
-    //   workspaceId: props.workspaceFile.workspaceId,
-    //   type: DmnRunnerPersistenceReducerActionType.PREVIOUS,
-    //   newPersistenceJson: {},
-    //   shouldUpdateFs: false,
-    //   cancellationToken: new Holder(false),
-    // });
   }, [props.workspaceFile.relativePath]);
 
   // Control the isExpaded state based on the extended services status;

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -171,6 +171,10 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
     setExtendedServicesError(false);
   }, [jsonSchema]);
 
+  useEffect(() => {
+    setJsonSchema(undefined);
+  }, [props.workspaceFile.relativePath]);
+
   // Control the isExpaded state based on the extended services status;
   useLayoutEffect(() => {
     if (props.workspaceFile.extension !== "dmn") {

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -41,7 +41,10 @@ import {
 import { useDmnRunnerPersistence } from "../dmnRunnerPersistence/DmnRunnerPersistenceHook";
 import { DmnLanguageService } from "@kie-tools/dmn-language-service";
 import { decoder } from "@kie-tools-core/workspaces-git-fs/dist/encoderdecoder/EncoderDecoder";
-import { generateUuid } from "../dmnRunnerPersistence/DmnRunnerPersistenceService";
+import {
+  generateUuid,
+  getNewDefaultDmnRunnerPersistenceJson,
+} from "../dmnRunnerPersistence/DmnRunnerPersistenceService";
 import { useDmnRunnerPersistenceDispatch } from "../dmnRunnerPersistence/DmnRunnerPersistenceDispatchContext";
 import cloneDeep from "lodash/cloneDeep";
 import { UnitablesInputsConfigs } from "@kie-tools/unitables/dist/UnitablesTypes";
@@ -567,6 +570,17 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
     )
   );
 
+  const onDeleteInputs = useCallback(() => {
+    // overwrite the current persistenceJson with a new one;
+    const newPersistenceJson = getNewDefaultDmnRunnerPersistenceJson();
+    // keep current mode;
+
+    setDmnRunnerPersistenceJson({
+      newConfigInputs: newPersistenceJson.configs.inputs,
+      newInputsRow: newPersistenceJson.inputs.map((input) => ({ ...getDefaultValues(jsonSchema ?? {}), ...input })),
+    });
+  }, [getDefaultValues, jsonSchema, setDmnRunnerPersistenceJson]);
+
   const getDefaultValuesForInputs = useCallback((inputs: InputRow) => {
     return Object.entries(inputs).reduce(
       (acc, [key, value]) => {
@@ -655,6 +669,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
   const dmnRunnerDispatch = useMemo(
     () => ({
       setDmnRunnerContextProviderState,
+      onDeleteInputs,
       onRowAdded,
       onRowDeleted,
       onRowDuplicated,
@@ -665,6 +680,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
       setDmnRunnerPersistenceJson,
     }),
     [
+      onDeleteInputs,
       onRowAdded,
       onRowDeleted,
       onRowDuplicated,

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -438,7 +438,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
       return "";
     }
     if (dmnField.type === "number") {
-      return;
+      return undefined;
     }
     if (dmnField.type === "array") {
       return [];
@@ -446,7 +446,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
     if (dmnField.type === "object") {
       return {};
     }
-    return;
+    return undefined;
   }, []);
 
   // The refreshCallback is called after a CompanionFS event;

--- a/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerContextProvider.tsx
@@ -360,7 +360,7 @@ export function DmnRunnerContextProvider(props: PropsWithChildren<Props>) {
           }
           return newDmnRunnerPersistenceJson;
         },
-        shouldUpdateFS: args.shouldUpdateFs !== undefined ? args.shouldUpdateFs : true,
+        shouldUpdateFs: args.shouldUpdateFs !== undefined ? args.shouldUpdateFs : true,
         cancellationToken: args.cancellationToken ?? new Holder(false),
       });
     },

--- a/packages/online-editor/src/dmnRunner/DmnRunnerTypes.ts
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerTypes.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { DecisionResult } from "@kie-tools/extended-services-api";
+import { DecisionResult, ExtendedServicesDmnJsonSchema } from "@kie-tools/extended-services-api";
+import { DmnRunnerPersistenceJson } from "../dmnRunnerPersistence/DmnRunnerPersistenceTypes";
 
 export interface DmnRunnerResults {
   results: Array<DecisionResult[] | undefined>;
@@ -60,3 +61,9 @@ export type DmnRunnerProviderAction =
   | DmnRunnerProviderActionDefault
   | DmnRunnerProviderActionAddRow
   | DmnRunnerProviderActionToggleExpanded;
+
+export interface DmnRunnerCompanionRefreshCallback {
+  propertiesDifference?: Record<string, any>;
+  jsonSchema?: ExtendedServicesDmnJsonSchema;
+  dmnRunnerPersistenceJson?: DmnRunnerPersistenceJson;
+}

--- a/packages/online-editor/src/dmnRunner/DmnRunnerTypes.ts
+++ b/packages/online-editor/src/dmnRunner/DmnRunnerTypes.ts
@@ -63,7 +63,6 @@ export type DmnRunnerProviderAction =
   | DmnRunnerProviderActionToggleExpanded;
 
 export interface DmnRunnerCompanionRefreshCallback {
-  propertiesDifference?: Record<string, any>;
   jsonSchema?: ExtendedServicesDmnJsonSchema;
   dmnRunnerPersistenceJson?: DmnRunnerPersistenceJson;
 }

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContext.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContext.tsx
@@ -25,8 +25,9 @@ import {
 
 interface DmnRunnerPersistenceDispatchContextType {
   dmnRunnerPersistenceService: DmnRunnerPersistenceService;
-  getPersistenceJsonForDownload: (workspaceFile: WorkspaceFile) => Promise<Blob | undefined>;
-  uploadPersistenceJson: (workspaceFile: WorkspaceFile, file: File) => void;
+  onDownloadDmnRunnerPersistenceJson: (workspaceFile: WorkspaceFile) => Promise<Blob | undefined>;
+  onUploadDmnRunnerPersistenceJson: (workspaceFile: WorkspaceFile, file: File) => void;
+  onDeleteDmnRunnerPersistenceJson: (workspaceFile: WorkspaceFile) => void;
   dmnRunnerPersistenceJson: DmnRunnerPersistenceJson;
   dmnRunnerPersistenceJsonDispatcher: React.Dispatch<DmnRunnerPersistenceReducerAction>;
   updatePersistenceJsonDebouce: (args: DmnRunnerUpdatePersistenceJsonDeboucerArgs) => void;

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContext.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContext.tsx
@@ -25,10 +25,6 @@ import {
 
 interface DmnRunnerPersistenceDispatchContextType {
   dmnRunnerPersistenceService: DmnRunnerPersistenceService;
-  deletePersistenceJson: (
-    previousDmnRunnerPersisnteceJson: DmnRunnerPersistenceJson,
-    workspaceFile: WorkspaceFile
-  ) => void;
   getPersistenceJsonForDownload: (workspaceFile: WorkspaceFile) => Promise<Blob | undefined>;
   uploadPersistenceJson: (workspaceFile: WorkspaceFile, file: File) => void;
   dmnRunnerPersistenceJson: DmnRunnerPersistenceJson;

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
@@ -65,14 +65,13 @@ function checkIfHasChangesAndUpdateFs(
   }
 
   // update FS;
+  LOCK = true;
   updatePersistenceJsonDebouce({
     workspaceId: workspaceId,
     workspaceFileRelativePath: workspaceFileRelativePath,
     content: JSON.stringify(newPersistenceJson),
     cancellationToken,
   });
-
-  LOCK = true;
   return newPersistenceJson;
 }
 

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
@@ -142,26 +142,6 @@ export function DmnRunnerPersistenceDispatchContextProvider(props: React.PropsWi
     [dmnRunnerPersistenceService]
   );
 
-  const deletePersistenceJson = useCallback(
-    (previousDmnRunnerPersisnteceJson: DmnRunnerPersistenceJson, workspaceFile: WorkspaceFile) => {
-      // overwrite the current persistenceJson with a new one;
-      const newPersistenceJson = getNewDefaultDmnRunnerPersistenceJson();
-      // keep current mode;
-      newPersistenceJson.configs.mode = previousDmnRunnerPersisnteceJson.configs.mode;
-
-      dmnRunnerPersistenceJsonDispatcher({
-        updatePersistenceJsonDebouce,
-        workspaceId: workspaceFile.workspaceId,
-        workspaceFileRelativePath: workspaceFile.relativePath,
-        type: DmnRunnerPersistenceReducerActionType.DEFAULT,
-        newPersistenceJson,
-        shouldUpdateFS: true,
-        cancellationToken: new Holder(false),
-      });
-    },
-    [updatePersistenceJsonDebouce]
-  );
-
   const getPersistenceJsonForDownload = useCallback(
     async (workspaceFile: WorkspaceFile) => {
       const persistenceJson = await dmnRunnerPersistenceService.companionFsService.get({
@@ -194,7 +174,6 @@ export function DmnRunnerPersistenceDispatchContextProvider(props: React.PropsWi
     <DmnRunnerPersistenceDispatchContext.Provider
       value={{
         dmnRunnerPersistenceService,
-        deletePersistenceJson,
         getPersistenceJsonForDownload,
         uploadPersistenceJson,
         updatePersistenceJsonDebouce,

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
@@ -57,7 +57,7 @@ function dmnRunnerPersistenceJsonReducer(
   }
 
   // The new value should update the FS;
-  if (action.shouldUpdateFS) {
+  if (action.shouldUpdateFs) {
     LOCK = true;
     action.updatePersistenceJsonDebouce({
       workspaceId: action.workspaceId,

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceDispatchContextProvider.tsx
@@ -56,28 +56,28 @@ function dmnRunnerPersistenceJsonReducer(
     return persistenceJson;
   }
 
-  // The new value should update the FS;
-  if (action.shouldUpdateFs) {
-    LOCK = true;
-    action.updatePersistenceJsonDebouce({
-      workspaceId: action.workspaceId,
-      workspaceFileRelativePath: action.workspaceFileRelativePath,
-      content: JSON.stringify(newPersistenceJson),
-      cancellationToken: action.cancellationToken,
-    });
-    return newPersistenceJson;
+  // Updates from local FS and the current value is different from the change, hence, a change occured while the FS is being updated;
+  if (!action.shouldUpdateFs) {
+    if (LOCK) {
+      // the last change was made by this tab; invalidate fsUpdate;
+      LOCK = false;
+      return persistenceJson;
+    } else {
+      // the last change wasn't made by this tab; overwrite
+      LOCK = false;
+      return newPersistenceJson;
+    }
   }
 
-  // Updates from local FS and the current value is different from the change, hence, a change occured while the FS is being updated;
-  if (LOCK) {
-    // the last change was made by this tab; invalidate fsUpdate;
-    LOCK = false;
-    return persistenceJson;
-  } else {
-    // the last change wasn't made by this tab; overwrite
-    LOCK = false;
-    return newPersistenceJson;
-  }
+  // The new value should update the FS;
+  LOCK = true;
+  action.updatePersistenceJsonDebouce({
+    workspaceId: action.workspaceId,
+    workspaceFileRelativePath: action.workspaceFileRelativePath,
+    content: JSON.stringify(newPersistenceJson),
+    cancellationToken: action.cancellationToken,
+  });
+  return newPersistenceJson;
 }
 
 const initialDmnRunnerPersistenceJson = getNewDefaultDmnRunnerPersistenceJson();

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceHook.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceHook.tsx
@@ -19,7 +19,6 @@ import { useCallback } from "react";
 import { useCancelableEffect } from "@kie-tools-core/react-hooks/dist/useCancelableEffect";
 import { useDmnRunnerPersistenceDispatch } from "./DmnRunnerPersistenceDispatchContext";
 import { decoder } from "@kie-tools-core/workspaces-git-fs/dist/encoderdecoder/EncoderDecoder";
-import { CompanionFsServiceBroadcastEvents } from "../companionFs/CompanionFsService";
 import { getNewDefaultDmnRunnerPersistenceJson } from "./DmnRunnerPersistenceService";
 import { DmnRunnerPersistenceReducerActionType, DmnRunnerPersistenceJson } from "./DmnRunnerPersistenceTypes";
 
@@ -27,64 +26,6 @@ import { DmnRunnerPersistenceReducerActionType, DmnRunnerPersistenceJson } from 
 export function useDmnRunnerPersistence(workspaceId?: string, workspaceFileRelativePath?: string) {
   const { dmnRunnerPersistenceService, dmnRunnerPersistenceJsonDispatcher, updatePersistenceJsonDebouce } =
     useDmnRunnerPersistenceDispatch();
-
-  // When another TAB updates the FS, it should sync up
-  useCancelableEffect(
-    useCallback(
-      ({ canceled }) => {
-        if (!workspaceFileRelativePath || !workspaceId) {
-          return;
-        }
-
-        const dmnRunnerPersistenceJsonFileUniqueId =
-          dmnRunnerPersistenceService.companionFsService.getUniqueFileIdentifier({
-            workspaceId: workspaceId,
-            workspaceFileRelativePath: workspaceFileRelativePath,
-          });
-
-        console.debug(`Subscribing to ${dmnRunnerPersistenceJsonFileUniqueId}`);
-        const broadcastChannel = new BroadcastChannel(dmnRunnerPersistenceJsonFileUniqueId);
-        broadcastChannel.onmessage = ({ data: companionEvent }: MessageEvent<CompanionFsServiceBroadcastEvents>) => {
-          if (canceled.get()) {
-            return;
-          }
-
-          console.debug(`EVENT::WORKSPACE_FILE: ${JSON.stringify(companionEvent)}`);
-          if (companionEvent.type === "CFSF_MOVE" || companionEvent.type == "CFSF_RENAME") {
-            // Ignore, as content remains the same.
-          } else if (
-            companionEvent.type === "CFSF_UPDATE" ||
-            companionEvent.type === "CFSF_ADD" ||
-            companionEvent.type === "CFSF_DELETE"
-          ) {
-            const dmnRunnerPersistenceJson: DmnRunnerPersistenceJson =
-              dmnRunnerPersistenceService.parseDmnRunnerPersistenceJson(companionEvent.content);
-
-            dmnRunnerPersistenceJsonDispatcher({
-              updatePersistenceJsonDebouce,
-              workspaceId: workspaceId,
-              workspaceFileRelativePath: workspaceFileRelativePath,
-              type: DmnRunnerPersistenceReducerActionType.DEFAULT,
-              newPersistenceJson: dmnRunnerPersistenceJson,
-              shouldUpdateFS: false,
-            });
-          }
-        };
-
-        return () => {
-          console.debug(`Unsubscribing to ${dmnRunnerPersistenceJsonFileUniqueId}`);
-          broadcastChannel.close();
-        };
-      },
-      [
-        updatePersistenceJsonDebouce,
-        dmnRunnerPersistenceService,
-        workspaceId,
-        workspaceFileRelativePath,
-        dmnRunnerPersistenceJsonDispatcher,
-      ]
-    )
-  );
 
   // On first render load the persistence json;
   useCancelableEffect(
@@ -124,6 +65,7 @@ export function useDmnRunnerPersistence(workspaceId?: string, workspaceFileRelat
                 type: DmnRunnerPersistenceReducerActionType.DEFAULT,
                 newPersistenceJson: dmnRunnerPersistenceJson,
                 shouldUpdateFS: false,
+                cancellationToken: canceled,
               });
             });
           });

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceHook.tsx
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceHook.tsx
@@ -64,7 +64,7 @@ export function useDmnRunnerPersistence(workspaceId?: string, workspaceFileRelat
                 workspaceFileRelativePath: workspaceFileRelativePath,
                 type: DmnRunnerPersistenceReducerActionType.DEFAULT,
                 newPersistenceJson: dmnRunnerPersistenceJson,
-                shouldUpdateFS: false,
+                shouldUpdateFs: false,
                 cancellationToken: canceled,
               });
             });

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceTypes.ts
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceTypes.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Holder } from "@kie-tools-core/react-hooks/dist/Holder";
 import { InputRow } from "@kie-tools/form-dmn";
 import { UnitablesInputsConfigs } from "@kie-tools/unitables";
 
@@ -36,6 +37,7 @@ export type DmnRunnerUpdatePersistenceJsonDeboucerArgs = {
   workspaceId: string;
   workspaceFileRelativePath: string;
   content: string;
+  cancellationToken: Holder<boolean>;
 };
 
 export enum DmnRunnerPersistenceReducerActionType {
@@ -58,4 +60,5 @@ export type DmnRunnerPersistenceReducerAction = {
   workspaceFileRelativePath: string;
   workspaceId: string;
   shouldUpdateFS: boolean;
+  cancellationToken: Holder<boolean>;
 } & (DmnRunnerPersistenceReducerActionDefault | DmnRunnerPersistenceReducerActionPrevious);

--- a/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceTypes.ts
+++ b/packages/online-editor/src/dmnRunnerPersistence/DmnRunnerPersistenceTypes.ts
@@ -59,6 +59,6 @@ export type DmnRunnerPersistenceReducerAction = {
   updatePersistenceJsonDebouce: (args: DmnRunnerUpdatePersistenceJsonDeboucerArgs) => void;
   workspaceFileRelativePath: string;
   workspaceId: string;
-  shouldUpdateFS: boolean;
+  shouldUpdateFs: boolean;
   cancellationToken: Holder<boolean>;
 } & (DmnRunnerPersistenceReducerActionDefault | DmnRunnerPersistenceReducerActionPrevious);

--- a/packages/online-editor/src/editor/KieSandboxExtendedServices/KieSandboxExtendedServicesButtons.tsx
+++ b/packages/online-editor/src/editor/KieSandboxExtendedServices/KieSandboxExtendedServicesButtons.tsx
@@ -57,10 +57,9 @@ export function KieSandboxExtendedServicesButtons(props: Props) {
   const devDeployments = useDevDeployments();
   const { onTogglePanel, onOpenPanel } = useEditorDockContext();
   const { dmnRunnerPersistenceJson, isExpanded, mode } = useDmnRunnerState();
-  const { setDmnRunnerMode, setDmnRunnerContextProviderState } = useDmnRunnerDispatch();
+  const { setDmnRunnerMode, setDmnRunnerContextProviderState, onDeleteInputs } = useDmnRunnerDispatch();
   const devDeploymentsDropdownItems = useDevDeploymentsDeployDropdownItems(props.workspace);
-  const { getPersistenceJsonForDownload, uploadPersistenceJson, deletePersistenceJson } =
-    useDmnRunnerPersistenceDispatch();
+  const { getPersistenceJsonForDownload, uploadPersistenceJson } = useDmnRunnerPersistenceDispatch();
   const downloadDmnRunnerInputsRef = useRef<HTMLAnchorElement>(null);
   const uploadDmnRunnerInputsRef = useRef<HTMLInputElement>(null);
 
@@ -221,7 +220,7 @@ export function KieSandboxExtendedServicesButtons(props: Props) {
                       type: DmnRunnerProviderActionType.DEFAULT,
                       newState: { currentInputIndex: 0 },
                     });
-                    deletePersistenceJson(dmnRunnerPersistenceJson, props.workspaceFile);
+                    onDeleteInputs();
                   }}
                   item={`Delete DMN Runner inputs`}
                   label={" Delete inputs"}

--- a/packages/online-editor/src/editor/KieSandboxExtendedServices/KieSandboxExtendedServicesButtons.tsx
+++ b/packages/online-editor/src/editor/KieSandboxExtendedServices/KieSandboxExtendedServicesButtons.tsx
@@ -56,10 +56,11 @@ export function KieSandboxExtendedServicesButtons(props: Props) {
   const extendedServices = useExtendedServices();
   const devDeployments = useDevDeployments();
   const { onTogglePanel, onOpenPanel } = useEditorDockContext();
-  const { dmnRunnerPersistenceJson, isExpanded, mode } = useDmnRunnerState();
-  const { setDmnRunnerMode, setDmnRunnerContextProviderState, onDeleteInputs } = useDmnRunnerDispatch();
+  const { isExpanded, mode } = useDmnRunnerState();
+  const { setDmnRunnerMode, setDmnRunnerContextProviderState } = useDmnRunnerDispatch();
   const devDeploymentsDropdownItems = useDevDeploymentsDeployDropdownItems(props.workspace);
-  const { getPersistenceJsonForDownload, uploadPersistenceJson } = useDmnRunnerPersistenceDispatch();
+  const { onDeleteDmnRunnerPersistenceJson, onDownloadDmnRunnerPersistenceJson, onUploadDmnRunnerPersistenceJson } =
+    useDmnRunnerPersistenceDispatch();
   const downloadDmnRunnerInputsRef = useRef<HTMLAnchorElement>(null);
   const uploadDmnRunnerInputsRef = useRef<HTMLInputElement>(null);
 
@@ -96,23 +97,23 @@ export function KieSandboxExtendedServicesButtons(props: Props) {
 
   const handleDmnRunnerInputsDownload = useCallback(async () => {
     if (downloadDmnRunnerInputsRef.current) {
-      const fileBlob = await getPersistenceJsonForDownload(props.workspaceFile);
+      const fileBlob = await onDownloadDmnRunnerPersistenceJson(props.workspaceFile);
       if (fileBlob) {
         downloadDmnRunnerInputsRef.current.download = props.workspaceFile.name.split(".")[0] + ".json";
         downloadDmnRunnerInputsRef.current.href = URL.createObjectURL(fileBlob);
         downloadDmnRunnerInputsRef.current?.click();
       }
     }
-  }, [props.workspaceFile, getPersistenceJsonForDownload]);
+  }, [props.workspaceFile, onDownloadDmnRunnerPersistenceJson]);
 
   const handleDmnRunnerInputsUpload = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
       if (file) {
-        uploadPersistenceJson(props.workspaceFile, file);
+        onUploadDmnRunnerPersistenceJson(props.workspaceFile, file);
       }
     },
-    [uploadPersistenceJson, props.workspaceFile]
+    [onUploadDmnRunnerPersistenceJson, props.workspaceFile]
   );
 
   return (
@@ -220,7 +221,7 @@ export function KieSandboxExtendedServicesButtons(props: Props) {
                       type: DmnRunnerProviderActionType.DEFAULT,
                       newState: { currentInputIndex: 0 },
                     });
-                    onDeleteInputs();
+                    onDeleteDmnRunnerPersistenceJson(props.workspaceFile);
                   }}
                   item={`Delete DMN Runner inputs`}
                   label={" Delete inputs"}

--- a/packages/unitables/package.json
+++ b/packages/unitables/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@kie-tools-core/i18n": "workspace:*",
     "@kie-tools-core/notifications": "workspace:*",
+    "@kie-tools-core/react-hooks": "workspace:*",
     "@kie-tools/boxed-expression-component": "workspace:*",
     "@kie-tools/extended-services-api": "workspace:*",
     "@kie-tools/form": "workspace:*",

--- a/packages/unitables/package.json
+++ b/packages/unitables/package.json
@@ -41,6 +41,7 @@
     "ajv-errors": "^1.0.1",
     "deep-object-diff": "^1.1.0",
     "lodash": "^4.17.21",
+    "moment": "^2.29.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-id-generator": "^3.0.1",

--- a/packages/unitables/src/UnitablesContext.tsx
+++ b/packages/unitables/src/UnitablesContext.tsx
@@ -33,12 +33,9 @@ export function useUnitablesContext() {
 export function useUnitablesRow(rowIndex: number) {
   const { rowsRefs, rowsInputs } = useUnitablesContext();
 
-  const submitRow = useCallback(
-    (rowIndex: number) => {
-      rowsRefs.get(rowIndex)?.submit();
-    },
-    [rowsRefs]
-  );
+  const submitRow = useCallback(async () => {
+    rowsRefs.get(rowIndex)?.submit();
+  }, [rowsRefs, rowIndex]);
 
   return { submitRow, rowInputs: rowsInputs[rowIndex] };
 }

--- a/packages/unitables/src/UnitablesRow.tsx
+++ b/packages/unitables/src/UnitablesRow.tsx
@@ -74,7 +74,7 @@ export const UnitablesRow = React.forwardRef<UnitablesRowApi, PropsWithChildren<
           model={rowInput}
           onSubmit={onSubmit}
           placeholder={true}
-          validate={"onChange"}
+          validate={"onSubmit"}
           onValidate={onValidate}
         >
           <UniformsContext.Consumer>

--- a/packages/unitables/src/bee/UnitablesBeeTable.tsx
+++ b/packages/unitables/src/bee/UnitablesBeeTable.tsx
@@ -286,13 +286,8 @@ function UnitablesBeeTableCell({
             onFieldChange("");
           }
         } else if (field.format === "date-time") {
-          if (
-            moment(newValueWithoutSymbols, [
-              moment.HTML5_FMT.DATETIME_LOCAL,
-              moment.HTML5_FMT.DATETIME_LOCAL_SECONDS,
-              moment.HTML5_FMT.DATETIME_LOCAL_MS,
-            ]).isValid()
-          ) {
+          const valueAsNumber = Date.parse(newValueWithoutSymbols);
+          if (!isNaN(valueAsNumber)) {
             onFieldChange(newValueWithoutSymbols);
           } else {
             onFieldChange("");
@@ -312,11 +307,9 @@ function UnitablesBeeTableCell({
       } else {
         onFieldChange(newValue);
       }
-
-      // // submit row;
-      // rowsRefs.get(containerCellCoordinates?.rowIndex ?? 0)?.submit();
+      submitRow();
     },
-    [isBeeTableChange, field, onFieldChange]
+    [isBeeTableChange, field.enum, field.type, field.placeholder, field.format, submitRow, onFieldChange]
   );
 
   const { isActive, isEditing } = useBeeTableSelectableCellRef(
@@ -361,7 +354,7 @@ function UnitablesBeeTableCell({
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       // TAB
       if (e.key.toLowerCase() === "tab") {
-        submitRow?.(containerCellCoordinates?.rowIndex ?? 0);
+        submitRow();
         setEditingCell(false);
         if (isEnumField) {
           setIsSelectFieldOpen((prev) => {
@@ -398,7 +391,7 @@ function UnitablesBeeTableCell({
           cellRef.current?.getElementsByTagName("button")?.[0]?.click();
           setIsSelectFieldOpen((prev) => {
             if (prev === true) {
-              submitRow?.(containerCellCoordinates?.rowIndex ?? 0);
+              submitRow();
               setEditingCell(false);
             } else {
               setEditingCell(true);
@@ -416,7 +409,7 @@ function UnitablesBeeTableCell({
             return;
           }
         }
-        submitRow?.(containerCellCoordinates?.rowIndex ?? 0);
+        submitRow();
         setEditingCell(false);
         navigateVertically({ isShiftPressed: e.shiftKey });
         return;
@@ -431,7 +424,7 @@ function UnitablesBeeTableCell({
           // handle checkbox field;
           if (e.code.toLowerCase() === "space" && xDmnFieldType === X_DMN_TYPE.BOOLEAN) {
             cellRef.current?.getElementsByTagName("input")?.[0]?.click();
-            submitRow?.(containerCellCoordinates?.rowIndex ?? 0);
+            submitRow();
             return;
           } else {
             cellRef.current?.getElementsByTagName("input")?.[0]?.select();
@@ -445,16 +438,7 @@ function UnitablesBeeTableCell({
         e.stopPropagation();
       }
     },
-    [
-      xDmnFieldType,
-      containerCellCoordinates?.rowIndex,
-      isEditing,
-      isEnumField,
-      navigateVertically,
-      onFieldChange,
-      setEditingCell,
-      submitRow,
-    ]
+    [xDmnFieldType, isEditing, isEnumField, navigateVertically, onFieldChange, setEditingCell, submitRow]
   );
 
   // if it's active should focus on cell;
@@ -483,7 +467,7 @@ function UnitablesBeeTableCell({
   const onBlur = useCallback(
     (e: React.FocusEvent<HTMLDivElement>) => {
       if (e.target.tagName.toLowerCase() === "input") {
-        submitRow(containerCellCoordinates?.rowIndex ?? 0);
+        submitRow();
       }
       if (
         e.target.tagName.toLowerCase() === "button" ||
@@ -495,10 +479,10 @@ function UnitablesBeeTableCell({
           e.target.click();
           setIsSelectFieldOpen(false);
         }
-        submitRow(containerCellCoordinates?.rowIndex ?? 0);
+        submitRow();
       }
     },
-    [containerCellCoordinates?.rowIndex, fieldName, submitRow]
+    [fieldName, submitRow]
   );
 
   const onClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/unitables/src/bee/UnitablesBeeTable.tsx
+++ b/packages/unitables/src/bee/UnitablesBeeTable.tsx
@@ -262,12 +262,16 @@ function UnitablesBeeTableCell({
 
   // FIXME: Decouple from DMN --> https://github.com/kiegroup/kie-issues/issues/166
   const setValue = useCallback(
-    (newValue: string) => {
+    (newValue?: string) => {
       isBeeTableChange.current = true;
-      const newValueWithoutSymbols = newValue.replace(/\r/g, "");
+      const newValueWithoutSymbols = newValue?.replace(/\r/g, "") ?? "";
 
       if (field.enum) {
-        onFieldChange(field.placeholder);
+        if (field.enum.findIndex((value: unknown) => value === newValueWithoutSymbols) >= 0) {
+          onFieldChange(newValueWithoutSymbols);
+        } else {
+          onFieldChange(field.placeholder);
+        }
         // Changing the values using onChange will not re-render <select> nodes;
         // This ensure a re-render of the SelectField;
         forceUpdate();
@@ -458,7 +462,10 @@ function UnitablesBeeTableCell({
       if (e.target.tagName.toLowerCase() === "input") {
         submitRow(containerCellCoordinates?.rowIndex ?? 0);
       }
-      if (e.target.tagName.toLowerCase() === "button") {
+      if (
+        e.target.tagName.toLowerCase() === "button" ||
+        (e.relatedTarget as HTMLElement)?.tagName.toLowerCase() === "button"
+      ) {
         // if the select field is open and it blurs to another cell, close it;
         const selectOptions = document.getElementsByName(fieldName)?.[0]?.getElementsByTagName("button");
         if ((selectOptions?.length ?? 0) > 0 && (e.relatedTarget as HTMLElement).tagName.toLowerCase() === "td") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7377,6 +7377,9 @@ importers:
       "@kie-tools-core/notifications":
         specifier: workspace:*
         version: link:../notifications
+      "@kie-tools-core/react-hooks":
+        specifier: workspace:*
+        version: link:../react-hooks
       "@kie-tools/boxed-expression-component":
         specifier: workspace:*
         version: link:../boxed-expression-component

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7416,6 +7416,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      moment:
+        specifier: ^2.29.4
+        version: 2.29.4
       react:
         specifier: ^17.0.2
         version: 17.0.2

--- a/repo/graph.dot
+++ b/repo/graph.dot
@@ -366,6 +366,7 @@ digraph G {
   "@kie-tools/uniforms-patternfly-codegen" -> "@kie-tools-core/webpack-base" [ style = "dashed", color = "blue" ];
   "@kie-tools/uniforms-patternfly-codegen" -> "@kie-tools/eslint" [ style = "dashed", color = "blue" ];
   "@kie-tools/uniforms-patternfly-codegen" -> "@kie-tools/tsconfig" [ style = "dashed", color = "blue" ];
+  "@kie-tools/unitables" -> "@kie-tools-core/react-hooks" [ style = "solid", color = "blue" ];
   "@kie-tools/unitables" -> "@kie-tools/boxed-expression-component" [ style = "solid", color = "blue" ];
   "@kie-tools/unitables" -> "@kie-tools/extended-services-api" [ style = "solid", color = "blue" ];
   "@kie-tools/unitables" -> "@kie-tools/form" [ style = "solid", color = "blue" ];

--- a/repo/graph.json
+++ b/repo/graph.json
@@ -635,6 +635,7 @@
       { "source": "@kie-tools/unitables-dmn", "target": "@kie-tools/form-dmn", "weight": 1 },
       { "source": "@kie-tools/unitables-dmn", "target": "@kie-tools/unitables", "weight": 1 },
       { "source": "@kie-tools/kn-plugin-workflow", "target": "@kie-tools/root-env", "weight": 1 },
+      { "source": "@kie-tools/unitables", "target": "@kie-tools-core/react-hooks", "weight": 1 },
       { "source": "@kie-tools/unitables", "target": "@kie-tools/boxed-expression-component", "weight": 1 },
       { "source": "@kie-tools/unitables", "target": "@kie-tools/extended-services-api", "weight": 1 },
       { "source": "@kie-tools/unitables", "target": "@kie-tools/form", "weight": 1 },


### PR DESCRIPTION
## On this PR
 - Move CompanionFS sync hook to DmnRunnerContextProvider;
 - Add default values and remove changed data types during JSON schema update;
 - Add `cancellationToken` to `dmnRunnerInputsDispatcher` to prevent later state update;
 - Add comments and removed unnecessary functions;
 - Fix bug where focusing out the table wouldn't submit the table;
 - Fix bug where opening the SelectField with a click and navigating with the keyboard would keep the SelectField open;
 - Fix bug where the paste in the SelectField wouldn't work.
 - Fix batch update;
 - Fix date, time and date-time field copy/paste