### PR TITLE
Fix "Properties Panel" being hided after any change in row headers

### DIFF
--- a/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
+++ b/packages/boxed-expression-component/src/table/BeeTable/BeeTableTh.tsx
@@ -90,7 +90,7 @@ export function BeeTableTh<R extends object>({
   const { beeGwtService } = useBoxedExpressionEditor();
 
   useEffect(() => {
-    if (isActive) {
+    if (isActive && column.isRowIndexColumn) {
       beeGwtService?.selectObject("");
     }
   }, [beeGwtService, isActive]);


### PR DESCRIPTION
The `beeGwtService?.selectObject("");` should be called only when user selects a cell in a `rowIndexColumn` not in every header cell. For others headers cell, the `children` handles the call because sometimes is a call to select empty object sometimes is to select another `DomainObject` like the current expression, a rule from DecisionTable, and so on.