### PR TITLE
BPMN Editor: Snapping was not being considered and highlighting the SVG was not working with the Kogito SVG Add-on 

### DIFF
--- a/packages/bpmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/bpmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -1123,7 +1123,7 @@ export const LaneNodeSvg = React.forwardRef<SVGRectElement, NodeSvgProps & { gut
   const gutterWidth = _gutterWidth ?? 40;
 
   return (
-    <>
+    <g>
       <rect
         {...props}
         x={x}
@@ -1161,7 +1161,7 @@ export const LaneNodeSvg = React.forwardRef<SVGRectElement, NodeSvgProps & { gut
         ry={"0"}
         className={containerNodeInteractionRectCssClassName}
       />
-    </>
+    </g>
   );
 });
 

--- a/packages/bpmn-editor/src/diagram/nodes/NodeSvgs.tsx
+++ b/packages/bpmn-editor/src/diagram/nodes/NodeSvgs.tsx
@@ -29,8 +29,27 @@ import { containerNodeVisibleRectCssClassName } from "@kie-tools/xyflow-react-ki
 import { ActivityNodeMarker, EventVariant, GatewayVariant, SubProcessVariant, TaskVariant } from "../BpmnDiagramDomain";
 import { useMemo } from "react";
 
+// ################################################################
+// ###             Note on the Kogito SVG Add-on:               ###
+// ###                                                          ###
+// ###  There are only three possibilities for elements inside  ###
+// ###  elements with the bpmn2nodeid attribute:                ###
+// ###                                                          ###
+// ###  ?shapeType=BACKGROUND"                                  ###
+// ###  ?shapeType=BORDE&renderType=STROKE                      ###
+// ###  ?shapeType=BORDE&renderType=FILL                        ###
+// ###                                                          ###
+// ###  Here we only needed to use the first two.               ###
+// ###                                                          ###
+// ################################################################
+
 export function DataObjectNodeSvg(
-  __props: NodeSvgProps & { isIcon?: boolean; showFoldedPage?: boolean; showArrow?: boolean; transform?: string }
+  __props: NodeSvgProps & {
+    isIcon?: boolean;
+    showFoldedPage?: boolean;
+    showArrow?: boolean;
+    transform?: string;
+  }
 ) {
   const {
     x,
@@ -125,7 +144,9 @@ export const NODE_COLORS = {
   },
 } as const;
 
-export function StartEventNodeSvg(__props: NodeSvgProps & { variant: EventVariant | "none"; isInterrupting: boolean }) {
+export function StartEventNodeSvg(
+  __props: NodeSvgProps & { variant: EventVariant | "none"; isInterrupting: boolean; exportedSvgId?: string }
+) {
   const {
     x,
     y,
@@ -135,7 +156,7 @@ export function StartEventNodeSvg(__props: NodeSvgProps & { variant: EventVarian
     props: { ..._props },
   } = normalize(__props);
 
-  const { variant, isInterrupting, ...props } = { ..._props };
+  const { variant, isInterrupting, exportedSvgId, ...props } = { ..._props };
 
   const cx = x + width / 2;
   const cy = y + height / 2;
@@ -144,19 +165,44 @@ export function StartEventNodeSvg(__props: NodeSvgProps & { variant: EventVarian
 
   return (
     <>
-      <circle
-        cx={cx}
-        cy={cy}
-        strokeWidth={strokeWidth}
-        strokeDasharray={isInterrupting ? undefined : "9px 9px"}
-        width={width}
-        height={height}
-        fill={NODE_COLORS.startEvent.background}
-        stroke={NODE_COLORS.startEvent.foreground}
-        strokeLinejoin={"round"}
-        r={r}
-        {...props}
-      />
+      <g>
+        {/* 
+            Without this `g` element encapsulating the `circle` the Kogito SVG Add-on breaks,
+            as the BACKGROUND and BORDER shapes can't be in the same level.
+          */}
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BACKGROUND` } : {})}
+          cx={cx}
+          cy={cy}
+          strokeWidth={strokeWidth}
+          strokeDasharray={isInterrupting ? undefined : "9px 9px"}
+          width={width}
+          height={height}
+          fill={NODE_COLORS.startEvent.background}
+          stroke={NODE_COLORS.startEvent.foreground}
+          strokeLinejoin={"round"}
+          r={r}
+          {...props}
+        />
+      </g>
+
+      {exportedSvgId && (
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BORDER&renderType=STROKE` } : {})}
+          cx={cx}
+          cy={cy}
+          strokeWidth={strokeWidth}
+          strokeDasharray={isInterrupting ? undefined : "9px 9px"}
+          width={width}
+          height={height}
+          fill={"transparent"}
+          stroke={NODE_COLORS.startEvent.foreground}
+          strokeLinejoin={"round"}
+          r={r}
+          {...props}
+        />
+      )}
+
       <EventVariantSymbolSvg
         variant={variant}
         fill={NODE_COLORS.startEvent.background}
@@ -173,7 +219,12 @@ export function StartEventNodeSvg(__props: NodeSvgProps & { variant: EventVarian
   );
 }
 export function IntermediateCatchEventNodeSvg(
-  __props: NodeSvgProps & { rimWidth?: number; variant: EventVariant | "none"; isInterrupting: boolean }
+  __props: NodeSvgProps & {
+    rimWidth?: number;
+    variant: EventVariant | "none";
+    isInterrupting: boolean;
+    exportedSvgId?: string;
+  }
 ) {
   const {
     x,
@@ -184,7 +235,7 @@ export function IntermediateCatchEventNodeSvg(
     props: { ..._props },
   } = normalize(__props);
 
-  const { rimWidth, variant, isInterrupting, ...props } = { ..._props };
+  const { rimWidth, variant, isInterrupting, exportedSvgId, ...props } = { ..._props };
 
   const outerCircleRadius = width / 2;
   const innerCircleRadius = outerCircleRadius - (rimWidth ?? 5);
@@ -194,19 +245,44 @@ export function IntermediateCatchEventNodeSvg(
 
   return (
     <>
-      <circle
-        cx={cx}
-        cy={cy}
-        strokeWidth={strokeWidth}
-        width={width}
-        height={height}
-        strokeDasharray={isInterrupting ? undefined : "9px 9px"}
-        fill={NODE_COLORS.intermediateCatchEvent.background}
-        stroke={NODE_COLORS.intermediateCatchEvent.foreground}
-        strokeLinejoin={"round"}
-        r={outerCircleRadius}
-        {...props}
-      />
+      <g>
+        {/* 
+            Without this `g` element encapsulating the `circle` the Kogito SVG Add-on breaks,
+            as the BACKGROUND and BORDER shapes can't be in the same level.
+          */}
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BACKGROUND` } : {})}
+          cx={cx}
+          cy={cy}
+          strokeWidth={strokeWidth}
+          width={width}
+          height={height}
+          strokeDasharray={isInterrupting ? undefined : "9px 9px"}
+          fill={NODE_COLORS.intermediateCatchEvent.background}
+          stroke={NODE_COLORS.intermediateCatchEvent.foreground}
+          strokeLinejoin={"round"}
+          r={outerCircleRadius}
+          {...props}
+        />
+      </g>
+
+      {exportedSvgId && (
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BORDER&renderType=STROKE` } : {})}
+          cx={cx}
+          cy={cy}
+          strokeWidth={strokeWidth}
+          width={width}
+          height={height}
+          strokeDasharray={isInterrupting ? undefined : "9px 9px"}
+          fill={"transparent"}
+          stroke={NODE_COLORS.intermediateCatchEvent.foreground}
+          strokeLinejoin={"round"}
+          r={outerCircleRadius}
+          {...props}
+        />
+      )}
+
       <circle
         cx={cx}
         cy={cy}
@@ -236,7 +312,7 @@ export function IntermediateCatchEventNodeSvg(
   );
 }
 export function IntermediateThrowEventNodeSvg(
-  __props: NodeSvgProps & { rimWidth?: number; variant: EventVariant | "none" }
+  __props: NodeSvgProps & { rimWidth?: number; variant: EventVariant | "none"; exportedSvgId?: string }
 ) {
   const {
     x,
@@ -247,7 +323,7 @@ export function IntermediateThrowEventNodeSvg(
     props: { ..._props },
   } = normalize(__props);
 
-  const { rimWidth, variant, ...props } = { ..._props };
+  const { rimWidth, variant, exportedSvgId, ...props } = { ..._props };
 
   const outerCircleRadius = width / 2;
   const innerCircleRadius = outerCircleRadius - (rimWidth ?? 5);
@@ -257,18 +333,42 @@ export function IntermediateThrowEventNodeSvg(
 
   return (
     <>
-      <circle
-        cx={x + width / 2}
-        cy={y + height / 2}
-        strokeWidth={strokeWidth}
-        width={width}
-        height={height}
-        fill={NODE_COLORS.intermediateThrowEvent.background}
-        stroke={NODE_COLORS.intermediateThrowEvent.foreground}
-        strokeLinejoin={"round"}
-        r={outerCircleRadius}
-        {...props}
-      />
+      <g>
+        {/* 
+            Without this `g` element encapsulating the `circle` the Kogito SVG Add-on breaks,
+            as the BACKGROUND and BORDER shapes can't be in the same level.
+          */}
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BACKGROUND` } : {})}
+          cx={x + width / 2}
+          cy={y + height / 2}
+          strokeWidth={strokeWidth}
+          width={width}
+          height={height}
+          fill={NODE_COLORS.intermediateThrowEvent.background}
+          stroke={NODE_COLORS.intermediateThrowEvent.foreground}
+          strokeLinejoin={"round"}
+          r={outerCircleRadius}
+          {...props}
+        />
+      </g>
+
+      {exportedSvgId && (
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BORDER&renderType=STROKE` } : {})}
+          cx={x + width / 2}
+          cy={y + height / 2}
+          strokeWidth={strokeWidth}
+          width={width}
+          height={height}
+          fill={"transparent"}
+          stroke={NODE_COLORS.intermediateThrowEvent.foreground}
+          strokeLinejoin={"round"}
+          r={outerCircleRadius}
+          {...props}
+        />
+      )}
+
       <circle
         cx={x + width / 2}
         cy={y + height / 2}
@@ -296,7 +396,7 @@ export function IntermediateThrowEventNodeSvg(
     </>
   );
 }
-export function EndEventNodeSvg(__props: NodeSvgProps & { variant: EventVariant | "none" }) {
+export function EndEventNodeSvg(__props: NodeSvgProps & { variant: EventVariant | "none"; exportedSvgId?: string }) {
   const {
     x,
     y,
@@ -306,7 +406,7 @@ export function EndEventNodeSvg(__props: NodeSvgProps & { variant: EventVariant 
     props: { ..._props },
   } = normalize(__props);
 
-  const { variant, ...props } = { ..._props };
+  const { variant, exportedSvgId, ...props } = { ..._props };
 
   const cx = x + width / 2;
   const cy = y + height / 2;
@@ -315,18 +415,42 @@ export function EndEventNodeSvg(__props: NodeSvgProps & { variant: EventVariant 
 
   return (
     <>
-      <circle
-        cx={cx}
-        cy={cy}
-        strokeWidth={strokeWidth}
-        width={width}
-        height={height}
-        fill={NODE_COLORS.endEvent.background}
-        stroke={NODE_COLORS.endEvent.foreground}
-        strokeLinejoin={"round"}
-        r={r}
-        {...props}
-      />
+      <g>
+        {/* 
+            Without this `g` element encapsulating the `circle` the Kogito SVG Add-on breaks,
+            as the BACKGROUND and BORDER shapes can't be in the same level.
+          */}
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BACKGROUND` } : {})}
+          cx={cx}
+          cy={cy}
+          strokeWidth={strokeWidth}
+          width={width}
+          height={height}
+          fill={NODE_COLORS.endEvent.background}
+          stroke={NODE_COLORS.endEvent.foreground}
+          strokeLinejoin={"round"}
+          r={r}
+          {...props}
+        />
+      </g>
+
+      {exportedSvgId && (
+        <circle
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BORDER&renderType=STROKE` } : {})}
+          cx={cx}
+          cy={cy}
+          strokeWidth={strokeWidth}
+          width={width}
+          height={height}
+          fill={"transparent"}
+          stroke={NODE_COLORS.endEvent.foreground}
+          strokeLinejoin={"round"}
+          r={r}
+          {...props}
+        />
+      )}
+
       <EventVariantSymbolSvg
         variant={variant}
         fill={NODE_COLORS.endEvent.background}
@@ -348,6 +472,7 @@ export function TaskNodeSvg(
     variant?: TaskVariant | "task" | "callActivity" | "none";
     isIcon?: boolean;
     icon?: React.ReactNode;
+    exportedSvgId?: string;
   }
 ) {
   const {
@@ -359,7 +484,7 @@ export function TaskNodeSvg(
     props: { ..._props },
   } = normalize(__props);
 
-  const { markers: _markers, variant: _variant, variant, isIcon, icon } = { ..._props };
+  const { markers: _markers, variant: _variant, variant, isIcon, icon, exportedSvgId } = { ..._props };
 
   const markers = useMemo(() => new Set(_markers), [_markers]);
   const iconSize = 200;
@@ -375,18 +500,43 @@ export function TaskNodeSvg(
   return (
     <>
       {!isIcon && (
-        <rect
-          x={x}
-          y={y}
-          strokeWidth={strokeWidth}
-          width={width}
-          height={height}
-          fill={DEFAULT_NODE_FILL}
-          stroke={DEFAULT_NODE_STROKE_COLOR}
-          strokeLinejoin={"round"}
-          rx="3"
-          ry="3"
-        />
+        <>
+          <g>
+            {/* 
+                Without this `g` element encapsulating the `rect` the Kogito SVG Add-on breaks,
+                as the BACKGROUND and BORDER shapes can't be in the same level.
+              */}
+            <rect
+              {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BACKGROUND` } : {})}
+              x={x}
+              y={y}
+              strokeWidth={strokeWidth}
+              width={width}
+              height={height}
+              fill={DEFAULT_NODE_FILL}
+              stroke={DEFAULT_NODE_STROKE_COLOR}
+              strokeLinejoin={"round"}
+              rx="3"
+              ry="3"
+            />
+          </g>
+
+          {exportedSvgId && (
+            <rect
+              {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BORDER&renderType=STROKE` } : {})}
+              x={x}
+              y={y}
+              strokeWidth={0}
+              width={width}
+              height={height}
+              fill={"transparent"}
+              stroke={DEFAULT_NODE_STROKE_COLOR}
+              strokeLinejoin={"round"}
+              rx="3"
+              ry="3"
+            />
+          )}
+        </>
       )}
 
       {icon && <g transform={`translate(${iconOffsets.scriptTask.cx}, ${iconOffsets.scriptTask.cy})`}>{icon}</g>}
@@ -693,7 +843,9 @@ export function UserTaskSvg({ stroke, size }: { stroke: string; size: number }) 
     </svg>
   );
 }
-export function GatewayNodeSvg(__props: NodeSvgProps & { variant: GatewayVariant | "none"; isIcon?: boolean }) {
+export function GatewayNodeSvg(
+  __props: NodeSvgProps & { variant: GatewayVariant | "none"; isIcon?: boolean; exportedSvgId?: string }
+) {
   const {
     x,
     y,
@@ -703,20 +855,45 @@ export function GatewayNodeSvg(__props: NodeSvgProps & { variant: GatewayVariant
     props: { ..._props },
   } = normalize(__props);
 
-  const { variant, isIcon, ...props } = { ..._props };
+  const { variant, isIcon, exportedSvgId, ...props } = { ..._props };
   const iconOffset = isIcon ? 25 : 0;
 
   return (
     <>
       {!isIcon && (
+        <g>
+          {/* 
+              Without this `g` element encapsulating the `rect` the Kogito SVG Add-on breaks,
+              as the BACKGROUND and BORDER shapes can't be in the same level.
+            */}
+          <rect
+            {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BACKGROUND` } : {})}
+            x={8 + x}
+            y={8 + y}
+            transform={`rotate(45,${x + width / 2},${y + height / 2})`}
+            strokeWidth={strokeWidth}
+            width={width / 1.4} // sqrt(2)
+            height={height / 1.4} // sqrt(2)
+            fill={NODE_COLORS.gateway.background}
+            stroke={NODE_COLORS.gateway.foreground}
+            strokeLinejoin={"round"}
+            rx="5"
+            ry="5"
+            {...props}
+          />
+        </g>
+      )}
+
+      {exportedSvgId && (
         <rect
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BORDER&renderType=STROKE` } : {})}
           x={8 + x}
           y={8 + y}
           transform={`rotate(45,${x + width / 2},${y + height / 2})`}
           strokeWidth={strokeWidth}
           width={width / 1.4} // sqrt(2)
           height={height / 1.4} // sqrt(2)
-          fill={NODE_COLORS.gateway.background}
+          fill={"transparent"}
           stroke={NODE_COLORS.gateway.foreground}
           strokeLinejoin={"round"}
           rx="5"
@@ -724,6 +901,7 @@ export function GatewayNodeSvg(__props: NodeSvgProps & { variant: GatewayVariant
           {...props}
         />
       )}
+
       {variant === "parallelGateway" && (
         <ParallelGatewaySvg
           stroke={NODE_COLORS.gateway.foreground}
@@ -945,7 +1123,7 @@ export const LaneNodeSvg = React.forwardRef<SVGRectElement, NodeSvgProps & { gut
   const gutterWidth = _gutterWidth ?? 40;
 
   return (
-    <g>
+    <>
       <rect
         {...props}
         x={x}
@@ -983,7 +1161,7 @@ export const LaneNodeSvg = React.forwardRef<SVGRectElement, NodeSvgProps & { gut
         ry={"0"}
         className={containerNodeInteractionRectCssClassName}
       />
-    </g>
+    </>
   );
 });
 
@@ -994,6 +1172,7 @@ export const SubProcessNodeSvg = React.forwardRef<
     rimWidth?: number;
     icons?: ActivityNodeMarker[];
     variant?: SubProcessVariant;
+    exportedSvgId?: string;
   }
 >((__props, ref) => {
   const {
@@ -1001,8 +1180,10 @@ export const SubProcessNodeSvg = React.forwardRef<
     borderRadius: _borderRadius,
     icons: _icons,
     variant: _variant,
+    exportedSvgId: _exportedSvgId,
     ..._props
   } = { ...__props };
+
   const { x, y, width, height, strokeWidth, props } = normalize(_props);
 
   const {
@@ -1020,6 +1201,7 @@ export const SubProcessNodeSvg = React.forwardRef<
   const variant = _variant ?? "other";
   const rimWidth = variant === "transaction" ? _rimWidth ?? 5 : 0;
   const borderRadius = variant === "transaction" ? _borderRadius ?? 10 : 2;
+  const exportedSvgId = _exportedSvgId ?? undefined;
 
   return (
     <>
@@ -1039,37 +1221,68 @@ export const SubProcessNodeSvg = React.forwardRef<
           className={containerNodeVisibleRectCssClassName}
         />
       )}
-      <rect
-        {...props}
-        x={x}
-        y={y}
-        width={width}
-        height={height}
-        strokeWidth={strokeWidth}
-        fill={"transparent"}
-        stroke={DEFAULT_NODE_STROKE_COLOR}
-        strokeDasharray={variant === "event" ? "10,5" : undefined}
-        strokeLinejoin={"round"}
-        rx={borderRadius}
-        ry={borderRadius}
-        className={containerNodeVisibleRectCssClassName}
-      />
+
+      <g>
+        {/* 
+            Without this `g` element encapsulating the `rect` the Kogito SVG Add-on breaks,
+            as the BACKGROUND and BORDER shapes can't be in the same level.
+          */}
+        <rect
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BACKGROUND` } : {})}
+          {...props}
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          strokeWidth={strokeWidth}
+          fill={"transparent"}
+          stroke={DEFAULT_NODE_STROKE_COLOR}
+          strokeDasharray={variant === "event" ? "10,5" : undefined}
+          strokeLinejoin={"round"}
+          rx={borderRadius}
+          ry={borderRadius}
+          className={containerNodeVisibleRectCssClassName}
+        />
+      </g>
+
+      {exportedSvgId && (
+        <rect
+          {...(exportedSvgId ? { id: `${exportedSvgId}?shapeType=BORDER&renderType=STROKE` } : {})}
+          {...props}
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          strokeWidth={strokeWidth}
+          fill={"transparent"}
+          stroke={DEFAULT_NODE_STROKE_COLOR}
+          strokeDasharray={variant === "event" ? "10,5" : undefined}
+          strokeLinejoin={"round"}
+          rx={borderRadius}
+          ry={borderRadius}
+          className={containerNodeVisibleRectCssClassName}
+        />
+      )}
+
       {/* ↓ interaction rect */}
-      <rect
-        {...interactionRectProps}
-        ref={ref}
-        x={interactionRectX}
-        y={interactionRectY}
-        width={interactionRectWidth}
-        height={interactionRectHeight}
-        strokeWidth={interactionRectStrokeWidth}
-        fill={"transparent"}
-        stroke={"transparent"}
-        strokeLinejoin={"round"}
-        rx={"0"}
-        ry={"0"}
-        className={containerNodeInteractionRectCssClassName}
-      />
+      {!exportedSvgId && (
+        <rect
+          {...interactionRectProps}
+          ref={ref}
+          x={interactionRectX}
+          y={interactionRectY}
+          width={interactionRectWidth}
+          height={interactionRectHeight}
+          strokeWidth={interactionRectStrokeWidth}
+          fill={"transparent"}
+          stroke={"transparent"}
+          strokeLinejoin={"round"}
+          rx={"0"}
+          ry={"0"}
+          className={containerNodeInteractionRectCssClassName}
+        />
+      )}
+
       <ActivityNodeIcons x={x} y={y} width={width} height={height} icons={icons} />
     </>
   );

--- a/packages/bpmn-editor/src/svg/BpmnDiagramSvg.tsx
+++ b/packages/bpmn-editor/src/svg/BpmnDiagramSvg.tsx
@@ -320,7 +320,7 @@ export function BpmnDiagramSvg({
     });
 
     return { nodesSvg, nodesById };
-  }, [sortedNodesByParent]);
+  }, [customTasks, sortedNodesByParent]);
 
   return (
     <>

--- a/packages/bpmn-editor/src/svg/BpmnDiagramSvg.tsx
+++ b/packages/bpmn-editor/src/svg/BpmnDiagramSvg.tsx
@@ -26,6 +26,7 @@ import {
   BpmnNodeType,
   EventVariant,
   GatewayVariant,
+  MIN_NODE_SIZES,
   SubProcessVariant,
   TaskVariant,
 } from "../diagram/BpmnDiagramDomain";
@@ -51,7 +52,7 @@ import {
   UnknownNodeSvg,
 } from "../diagram/nodes/NodeSvgs";
 import { NODE_TYPES } from "../diagram/BpmnDiagramDomain";
-import { SnapGrid } from "@kie-tools/xyflow-react-kie-diagram/dist/snapgrid/SnapGrid";
+import { snapBounds, SnapGrid } from "@kie-tools/xyflow-react-kie-diagram/dist/snapgrid/SnapGrid";
 import { NodeLabelPosition } from "@kie-tools/xyflow-react-kie-diagram/dist/nodes/NodeSvgs";
 import { AssociationPath, SequenceFlowPath } from "../diagram/edges/EdgeSvgs";
 import { getShouldDisplayIsInterruptingFlag } from "../propertiesPanel/singleNodeProperties/StartEventProperties";
@@ -137,14 +138,16 @@ export function BpmnDiagramSvg({
           : "";
 
       return (
-        <g data-kie-bpmn-node-id={node.id} key={node.id}>
+        // bpmn2nodeid is necessary for the Kogito SVG Add-on
+        <g id={node.id} data-kie-bpmn-node-id={node.id} key={node.id} {...({ bpmn2nodeid: node.id } as any)}>
           {node.type === NODE_TYPES.dataObject && (
             <DataObjectNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               showFoldedPage={true}
+              // Doesn't need to be painted by the Kogito SVG Add-on
               {...style}
             />
           )}
@@ -154,11 +157,12 @@ export function BpmnDiagramSvg({
               bpmnElement={node?.data?.bpmnElement as BpmnElementActivitytIcons}
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               variant={getBpmnNodeVariant<typeof NODE_TYPES.task>(NODE_TYPES.task, node?.data?.bpmnElement)}
               strokeWidth={node?.data?.bpmnElement?.__$$element === "callActivity" ? 5 : undefined}
               customTasks={customTasks}
+              exportedSvgId={node.id}
               {...style}
             />
           )}
@@ -166,9 +170,10 @@ export function BpmnDiagramSvg({
             <GroupNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               strokeWidth={3}
+              // Doesn't need to be painted by the Kogito SVG Add-on
               {...style}
             />
           )}
@@ -176,8 +181,9 @@ export function BpmnDiagramSvg({
             <TextAnnotationNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
+              // Doesn't need to be painted by the Kogito SVG Add-on
               {...style}
             />
           )}
@@ -185,8 +191,8 @@ export function BpmnDiagramSvg({
             <StartEventNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               variant={getBpmnNodeVariant<typeof NODE_TYPES.startEvent>(NODE_TYPES.startEvent, node?.data?.bpmnElement)}
               isInterrupting={
                 getShouldDisplayIsInterruptingFlag(
@@ -197,6 +203,7 @@ export function BpmnDiagramSvg({
                     START_EVENT_NODE_ON_EVENT_SUB_PROCESSES_IS_INTERRUPTING_DEFAULT_VALUE
                   : START_EVENT_NODE_ON_EVENT_SUB_PROCESSES_IS_INTERRUPTING_DEFAULT_VALUE
               }
+              exportedSvgId={node.id}
               {...style}
             />
           )}
@@ -204,8 +211,8 @@ export function BpmnDiagramSvg({
             <IntermediateCatchEventNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               variant={getBpmnNodeVariant<typeof NODE_TYPES.intermediateCatchEvent>(
                 NODE_TYPES.intermediateCatchEvent,
                 node?.data?.bpmnElement
@@ -215,6 +222,7 @@ export function BpmnDiagramSvg({
                   ? node?.data?.bpmnElement["@_cancelActivity"] ?? BOUNDARY_EVENT_CANCEL_ACTIVITY_DEFAULT_VALUE
                   : true
               }
+              exportedSvgId={node.id}
               {...style}
             />
           )}
@@ -222,12 +230,13 @@ export function BpmnDiagramSvg({
             <IntermediateThrowEventNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               variant={getBpmnNodeVariant<typeof NODE_TYPES.intermediateThrowEvent>(
                 NODE_TYPES.intermediateThrowEvent,
                 node?.data?.bpmnElement
               )}
+              exportedSvgId={node.id}
               {...style}
             />
           )}
@@ -235,9 +244,10 @@ export function BpmnDiagramSvg({
             <GatewayNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               variant={getBpmnNodeVariant<typeof NODE_TYPES.gateway>(NODE_TYPES.gateway, node?.data?.bpmnElement)}
+              exportedSvgId={node.id}
               {...style}
             />
           )}
@@ -245,10 +255,11 @@ export function BpmnDiagramSvg({
             <EndEventNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               variant={getBpmnNodeVariant<typeof NODE_TYPES.endEvent>(NODE_TYPES.endEvent, node?.data?.bpmnElement)}
               strokeWidth={6}
+              exportedSvgId={node.id}
               {...style}
             />
           )}
@@ -259,9 +270,10 @@ export function BpmnDiagramSvg({
               bpmnElement={node?.data?.bpmnElement as BpmnElementActivitytIcons}
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
               variant={getBpmnNodeVariant<typeof NODE_TYPES.subProcess>(NODE_TYPES.subProcess, node?.data?.bpmnElement)}
+              exportedSvgId={node.id}
               {...style}
             />
           )}
@@ -269,8 +281,9 @@ export function BpmnDiagramSvg({
             <LaneNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
+              // Doesn't need to be painted by the Kogito SVG Add-on
               {...style}
             />
           )}
@@ -278,8 +291,9 @@ export function BpmnDiagramSvg({
             <UnknownNodeSvg
               width={node.width!}
               height={node.height!}
-              x={node.positionAbsolute!.x}
-              y={node.positionAbsolute!.y}
+              x={node.position!.x}
+              y={node.position!.y}
+              // Doesn't need to be painted by the Kogito SVG Add-on
               {...style}
             />
           )}
@@ -306,7 +320,7 @@ export function BpmnDiagramSvg({
     });
 
     return { nodesSvg, nodesById };
-  }, [customTasks, sortedNodesByParent]);
+  }, [sortedNodesByParent]);
 
   return (
     <>
@@ -314,29 +328,37 @@ export function BpmnDiagramSvg({
       {edges.map((e) => {
         const s = nodesById?.get(e.source);
         const t = nodesById?.get(e.target);
+
         const { path } = getSnappedMultiPointAnchoredEdgePath({
-          snapGrid,
+          snapGrid: {
+            isEnabled: snapGrid.isEnabled,
+            x: snapGrid.x / 2,
+            y: snapGrid.y / 2,
+          },
           edge: e.data?.bpmnEdge,
+          snappedSourceNodeBounds: snapBounds(
+            snapGrid,
+            s?.data.shape?.["dc:Bounds"],
+            e.data?.bpmnSourceType
+              ? MIN_NODE_SIZES[e.data?.bpmnSourceType]({ snapGrid })
+              : { "@_height": 0, "@_width": 0 }
+          ),
+          snappedTargetNodeBounds: snapBounds(
+            snapGrid,
+            t?.data.shape?.["dc:Bounds"],
+            e.data?.bpmnTargetType
+              ? MIN_NODE_SIZES[e.data?.bpmnTargetType]({ snapGrid })
+              : { "@_height": 0, "@_width": 0 }
+          ),
           shapeSource: e.data?.bpmnShapeSource,
           shapeTarget: e.data?.bpmnShapeTarget,
-          snappedSourceNodeBounds: {
-            x: s?.positionAbsolute?.x,
-            y: s?.positionAbsolute?.y,
-            width: s?.width,
-            height: s?.height,
-          },
-          snappedTargetNodeBounds: {
-            x: t?.positionAbsolute?.x,
-            y: t?.positionAbsolute?.y,
-            width: t?.width,
-            height: t?.height,
-          },
         });
         return (
-          <React.Fragment key={e.id}>
+          // bpmn2nodeid is necessary for the Kogito SVG Add-on
+          <g key={e.id} id={e.id} {...({ bpmn2nodeid: e.id } as any)}>
             {e.type === EDGE_TYPES.sequenceFlow && <SequenceFlowPath d={path} />}
             {e.type === EDGE_TYPES.association && <AssociationPath d={path} />}
-          </React.Fragment>
+          </g>
         );
       })}
       {nodesSvg}


### PR DESCRIPTION
The solution here was to properly call snapping methods for Edges and change positionAbsolute to position.

Reverse-engineered the Kogito SVG Add-on and found out there's a logic with the bpmn2nodeid and id attributes. After painstakingly figuring it out, it worked.

