### PR TITLE
[i18n]: Few strings in Keyboard shortcuts is not translated

### DIFF
--- a/packages/bpmn-editor/src/i18n/BpmnEditorI18n.ts
+++ b/packages/bpmn-editor/src/i18n/BpmnEditorI18n.ts
@@ -356,6 +356,11 @@ interface BpmnEditorDictionary
       anyError: string;
       addError: string;
     };
+    overlaysPanel: {
+      snapping: string;
+      horizontal: string;
+      vertical: string;
+    };
   }> {}
 
 export interface BpmnEditorI18n extends BpmnEditorDictionary, CommonI18n {}

--- a/packages/bpmn-editor/src/i18n/locales/en.ts
+++ b/packages/bpmn-editor/src/i18n/locales/en.ts
@@ -361,4 +361,9 @@ export const en: BpmnEditorI18n = {
     anyError: `Your model doesn't have any error property.`,
     addError: "Add error",
   },
+  overlaysPanel: {
+    snapping: "Snapping",
+    horizontal: "Horizontal",
+    vertical: "Vertical",
+  },
 };

--- a/packages/bpmn-editor/src/overlaysPanel/OverlaysPanel.tsx
+++ b/packages/bpmn-editor/src/overlaysPanel/OverlaysPanel.tsx
@@ -61,7 +61,7 @@ export function OverlaysPanel({ availableHeight }: OverlaysPanelProps) {
         onKeyDown={(e) => e.stopPropagation()} // Prevent ReactFlow KeyboardShortcuts from triggering when editing stuff on Overlays Panel
         style={{ width: "300px" }}
       >
-        <FormGroup label="Snapping">
+        <FormGroup label={i18n.overlaysPanel.snapping}>
           <Switch
             aria-label={"Snapping"}
             isChecked={snapGrid.isEnabled}
@@ -72,7 +72,7 @@ export function OverlaysPanel({ availableHeight }: OverlaysPanelProps) {
             }
           />
         </FormGroup>
-        <FormGroup label="Horizontal">
+        <FormGroup label={i18n.overlaysPanel.horizontal}>
           <Slider
             data-testid={"kie-tools--bpmn-editor--horizontal-snapping-control"}
             className={"kie-bpmn-editor--snap-slider"}
@@ -95,7 +95,7 @@ export function OverlaysPanel({ availableHeight }: OverlaysPanelProps) {
             }
           />
         </FormGroup>
-        <FormGroup label="Vertical">
+        <FormGroup label={i18n.overlaysPanel.vertical}>
           <Slider
             data-testid={"kie-tools--bpmn-editor--vertical-snapping-control"}
             className={"kie-bpmn-editor--snap-slider"}


### PR DESCRIPTION
Fixed translation forShow keyboard shortcuts and bpmn-editor strings.